### PR TITLE
ci: serialize testing for different python versions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9"]
+      max-parallel: 1
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Serializing testing for python versions due to "[400] Bad Request - Error: Cannot create policy ***-default-XXX because it already exists in database." errors when creating queries/policies.