### PR TITLE
Changed the Jupyter helper, adding ability to define helper functions

### DIFF
--- a/jupyter/MANIFEST.in
+++ b/jupyter/MANIFEST.in
@@ -1,0 +1,1 @@
+include laceworkjupyter/features/*.yaml

--- a/jupyter/docker/docker_build/00-import.py
+++ b/jupyter/docker/docker_build/00-import.py
@@ -4,8 +4,11 @@ import altair as alt
 import pandas as pd
 import numpy as np
 
-from laceworkjupyter import LaceworkJupyterHelper
+import laceworkjupyter
 from laceworkjupyter import utils
+
+# Keeping for legacy reasons.
+from laceworkjupyter.helper import LaceworkJupyterClient LaceworkJupyterHelper
 
 import snowflake.connector
 
@@ -15,3 +18,6 @@ import ds4n6_lib as ds
 
 # Enable the Picatrix helpers.
 notebook_init.init()
+
+# Enable the LW object.
+lw = laceworkjupyter.LaceworkHelper()

--- a/jupyter/docker/docker_build/00-import.py
+++ b/jupyter/docker/docker_build/00-import.py
@@ -8,7 +8,7 @@ import laceworkjupyter
 from laceworkjupyter import utils
 
 # Keeping for legacy reasons.
-from laceworkjupyter.helper import LaceworkJupyterClient LaceworkJupyterHelper
+from laceworkjupyter.helper import LaceworkJupyterClient as LaceworkJupyterHelper
 
 import snowflake.connector
 

--- a/jupyter/docker/docker_build/lacework/main.js
+++ b/jupyter/docker/docker_build/lacework/main.js
@@ -20,10 +20,10 @@ define([
         new_cell.focus_cell();
 
         var import_cell = Jupyter.notebook.insert_cell_below('code');
-        import_cell.set_text('client = LaceworkJupyterHelper()');
+        import_cell.set_text('client = lw.get_client()');
 
         var new_cell = Jupyter.notebook.insert_cell_below('markdown');
-        new_cell.set_text('## Connecting to Lacework\nBasic imports have already been completed, we now need to connect to the Lacework API using the Jupyter helper.\nExecute the cell below by pressing the play button or using "shift + enter"');
+        new_cell.set_text('## Connecting to Lacework\nBasic imports have already been completed, we now need to connect to the Lacework API using the Jupyter helper.\nExecute the cell below by pressing the play button or using "shift + enter"\n\nAlll Lacework SDK actions happen on either the lw object or the client, which can be gathered using the lw.get_client() function.');
         new_cell.render();
         import_cell.focus_cell();
     };

--- a/jupyter/docker/docker_build/snippets.json
+++ b/jupyter/docker/docker_build/snippets.json
@@ -3,7 +3,7 @@
     {
       "name": "Get a new client",
       "code" : [
-        "client = LaceworkJupyterHelper()"
+        "client = lw.get_client()"
       ]
     },
     {

--- a/jupyter/laceworkjupyter/__init__.py
+++ b/jupyter/laceworkjupyter/__init__.py
@@ -1,70 +1,58 @@
+"""Defines helpers for interacting with the Lacework API in a notebook."""
 import logging
-import os
 
-from laceworksdk import LaceworkClient
-
-from . import config
 from . import decorators
-from . import plugins
+from . import features
+from . import manager
+
+# TODO: Remove this, kept for maintaining backward compatability
+# for the original design. Will be removed after a grace period.
+from .helper import LaceworkJupyterClient as LaceworkJupyterHelper
 
 
 logger = logging.getLogger('lacework_sdk.jupyter.client')
 
 
-class APIWrapper:
+class LaceworkContext:
     """
-    API Wrapper class that takes an API wrapper and decorates functions.
+    A simple context class for working in a notebook environment.
     """
 
-    def __init__(self, api_wrapper, wrapper_name):
-        self._api_wrapper = api_wrapper
-        self._api_name = wrapper_name
+    def __init__(self):
+        self._cache = {}
+        self.client = None
 
-        for func_name in [f for f in dir(api_wrapper) if not f.startswith('_')]:
-            func = getattr(api_wrapper, func_name)
+    def set_client(self, client):
+        self.client = client
 
-            decorator_plugin = plugins.PLUGINS.get(
-                f"{self._api_name}.{func_name}")
-            if decorator_plugin:
-                setattr(
-                    self,
-                    func_name,
-                    decorators.plugin_decorator(func, decorator_plugin))
-            else:
-                setattr(self, func_name, decorators.dataframe_decorator(func))
+    def add(self, key, value):
+        self._cache[key] = value
+
+    def get(key, default_value=None):
+        return self._cache.get(key, default_value)
 
 
-class LaceworkJupyterHelper:
+class LaceworkHelper:
     """
     Lacework Jupyter helper class.
 
-    This is a simple class that acts as a Jupyter wrapper around the
-    Python Lacework SDK. It simply wraps the SDK functions to return
-    a DataFrame instead of a dict when calling API functions.
+    This is a simple class that can be used to interact with
+    the Lacework API. It provides access to an API client,
+    wrapped for better notebook experience as well as
+    other helper functions.
     """
 
-    def __init__(
-            self, api_key=None, api_secret=None, account=None,
-            subaccount=None, instance=None, base_domain=None,
-            profile=None):
+    def __init__(self):
+        self.ctx = LaceworkContext()
 
-        self.sdk = LaceworkClient(
-            api_key=api_key, api_secret=api_secret,
-            account=account, subaccount=subaccount,
-            instance=instance, base_domain=base_domain,
-            profile=profile)
-
-        wrappers = [w for w in dir(self.sdk) if not w.startswith('_')]
-        for wrapper in wrappers:
-            wrapper_object = getattr(self.sdk, wrapper)
-            api_wrapper = APIWrapper(wrapper_object, wrapper_name=wrapper)
-            setattr(self, wrapper, api_wrapper)
+        for feature, feature_name in manager.LaceworkManager.get_features():
+            feature_fn = decorators.feature_decorator(feature, self.ctx)
+            setattr(self, feature_name, feature_fn)
 
     def __enter__(self):
         """
         Support the with statement in python.
         """
-        self.load_config()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/jupyter/laceworkjupyter/__init__.py
+++ b/jupyter/laceworkjupyter/__init__.py
@@ -41,7 +41,7 @@ class LaceworkContext:
         """
         self._cache[key] = value
 
-    def get(key, default_value=None):
+    def get(self, key, default_value=None):
         """
         Get a value from the cache.
 

--- a/jupyter/laceworkjupyter/__init__.py
+++ b/jupyter/laceworkjupyter/__init__.py
@@ -23,12 +23,34 @@ class LaceworkContext:
         self.client = None
 
     def set_client(self, client):
+        """
+        Set the Lacework client inside the context.
+
+        :param obj client: The client, instance of LaceworkJupyterClient.
+        """
         self.client = client
 
     def add(self, key, value):
+        """
+        Add an entry into the context's cache.
+
+        If the key already exists, the value in the cache is overwritten.
+
+        :param str key: The key, or name used to store the value in the cache.
+        :param obj value: The value, which can be any object.
+        """
         self._cache[key] = value
 
     def get(key, default_value=None):
+        """
+        Get a value from the cache.
+
+        :param str key: The key, or name used to store the value in the cache.
+        :param obj default_value: The default value that is returned if the
+            cache key is not stored in the cache. Defaults to None.
+        :return: The value in the cache, and if not found returns the default
+            value.
+        """
         return self._cache.get(key, default_value)
 
 

--- a/jupyter/laceworkjupyter/__init__.py
+++ b/jupyter/laceworkjupyter/__init__.py
@@ -2,12 +2,12 @@
 import logging
 
 from . import decorators
-from . import features
+from . import features  # noqa: F401
 from . import manager
 
 # TODO: Remove this, kept for maintaining backward compatability
 # for the original design. Will be removed after a grace period.
-from .helper import LaceworkJupyterClient as LaceworkJupyterHelper
+from .helper import LaceworkJupyterClient as LaceworkJupyterHelper  # noqa: F401
 
 
 logger = logging.getLogger('lacework_sdk.jupyter.client')

--- a/jupyter/laceworkjupyter/decorators.py
+++ b/jupyter/laceworkjupyter/decorators.py
@@ -14,7 +14,11 @@ def dataframe_decorator(function):
         data = function(*args, **kwargs)
 
         if isinstance(data, dict):
-            df = pd.DataFrame(data.get('data', []))
+            data_items = data.get('data', [])
+            if isinstance(data_items, dict):
+                data_items = [data_items]
+
+            df = pd.DataFrame(data_items)
             if 'SEVERITY' in df:
                 df['SEVERITY'] = df.SEVERITY.apply(
                     lambda x: config.SEVERITY_DICT.get(x, x))
@@ -35,3 +39,16 @@ def plugin_decorator(function, output_plugin):
         return output_plugin(data)
 
     return get_output
+
+
+def feature_decorator(function, ctx=None):
+    """
+    A decorator that adds a context to a function call.
+    """
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        if ctx:
+            kwargs['ctx'] = ctx
+        return function(*args, **kwargs)
+
+    return wrapper

--- a/jupyter/laceworkjupyter/features/__init__.py
+++ b/jupyter/laceworkjupyter/features/__init__.py
@@ -1,0 +1,4 @@
+"""A simple loading of helper functions."""
+
+from . import client
+from . import query

--- a/jupyter/laceworkjupyter/features/__init__.py
+++ b/jupyter/laceworkjupyter/features/__init__.py
@@ -1,4 +1,4 @@
 """A simple loading of helper functions."""
 
-from . import client
-from . import query
+from . import client  # noqa: F401
+from . import query  # noqa: F401

--- a/jupyter/laceworkjupyter/features/client.py
+++ b/jupyter/laceworkjupyter/features/client.py
@@ -1,0 +1,26 @@
+# A simple class to get a jupyter client.
+
+from laceworkjupyter import helper
+from laceworkjupyter import manager
+
+
+def get_client(
+        api_key=None, api_secret=None, account=None,
+        subaccount=None, instance=None, base_domain=None,
+        profile=None, ctx=None):
+    """
+    Returns a Lacework API client for use in a notebook.
+
+    :return: An instance of a LaceworkJupyterClient.
+    """
+
+    client = helper.LaceworkJupyterClient(
+        api_key=None, api_secret=None, account=None,
+        subaccount=None, instance=None, base_domain=None,
+        profile=None)
+
+    ctx.set_client(client)
+    return client
+
+
+manager.LaceworkManager.add_feature(get_client, 'get_client')

--- a/jupyter/laceworkjupyter/features/query.py
+++ b/jupyter/laceworkjupyter/features/query.py
@@ -1,4 +1,6 @@
-"""Provides a quick access to predefined LQL queries."""
+"""
+Provides a quick access to predefined LQL queries.
+"""
 import os
 
 import yaml
@@ -10,7 +12,8 @@ from laceworkjupyter import utils
 
 
 def _get_arguments(days=0, start_time="", end_time=""):
-    """Returns an argument dict for LQL queries.
+    """
+    Returns an argument dict for LQL queries.
 
     :param int days: Optional number of days from today.
     :param str start_time: Start date in an ISO format.
@@ -33,7 +36,8 @@ def _get_arguments(days=0, start_time="", end_time=""):
 
 
 def _run_query(query, arguments, evaluator=None, ctx=None):
-    """Runs a LQL query and returns a dataframe with the results.
+    """
+    Runs a LQL query and returns a dataframe with the results.
 
     :param str query: The LQL query to run.
     :param dict arguments: A dict containing the arguments to send to the LQL
@@ -54,7 +58,8 @@ def _run_query(query, arguments, evaluator=None, ctx=None):
 
 
 def _query_function(query_dict):
-    """Generates a function to query LQL from a query dictionary.
+    """
+    Generates a function to query LQL from a query dictionary.
 
     :param dict query_dict: A dictionary that contains the query as well
         as additional parameters.
@@ -64,7 +69,8 @@ def _query_function(query_dict):
     def wrapper(
             days=0, start_time="", end_time="", ctx=None,
             help=False, **kwargs):
-        """Query LQL and return back a DataFrame with the discovered content.
+        """
+        Query LQL and return back a DataFrame with the discovered content.
 
         :param int days: Number of days to query back in time.
         :param str start_time: ISO formatted timestamp of the start time of
@@ -83,7 +89,7 @@ def _query_function(query_dict):
         if not query:
             raise ValueError("There is no query defined.")
 
-        params = query_dict.get('params', [])
+        params = query_dict.get("params", [])
         if help:
             return pd.DataFrame(params)
 
@@ -96,7 +102,6 @@ def _query_function(query_dict):
         for parameter in params:
             # TODO: Add type checking.
             param_name = parameter.get("name", "__not_exists__")
-            # TOOD: Add to docstring.
             if param_name not in kwargs:
                 raise ValueError(
                     "Unable to run, missing parameter: {0:s}".format(
@@ -120,12 +125,12 @@ def _query_function(query_dict):
 
 
 query_feature_directory = os.path.dirname(__file__)
-query_yaml_path = os.path.join(query_feature_directory, 'query.yaml')
+query_yaml_path = os.path.join(query_feature_directory, "query.yaml")
 
 if os.path.isfile(query_yaml_path):
-    with open(query_yaml_path, 'r') as fh:
+    with open(query_yaml_path, "r") as fh:
         data = yaml.safe_load(fh)
-        for query_dict in data.get('queries', []):
+        for query_dict in data.get("queries", []):
             name = query_dict.get("name", "")
             function_name = f"query_{name}"
             function_fn = _query_function(query_dict)

--- a/jupyter/laceworkjupyter/features/query.py
+++ b/jupyter/laceworkjupyter/features/query.py
@@ -6,7 +6,6 @@ import os
 import yaml
 import pandas as pd
 
-from laceworkjupyter import helper
 from laceworkjupyter import manager
 from laceworkjupyter import utils
 

--- a/jupyter/laceworkjupyter/features/query.py
+++ b/jupyter/laceworkjupyter/features/query.py
@@ -1,0 +1,133 @@
+"""Provides a quick access to predefined LQL queries."""
+import os
+
+import yaml
+import pandas as pd
+
+from laceworkjupyter import helper
+from laceworkjupyter import manager
+from laceworkjupyter import utils
+
+
+def _get_arguments(days=0, start_time="", end_time=""):
+    """Returns an argument dict for LQL queries.
+
+    :param int days: Optional number of days from today.
+    :param str start_time: Start date in an ISO format.
+    :param str end_tune: End date in an ISO format.
+    :return: A dict with arguments that can be passed on to a LQL query API.
+    """
+    if days:
+        start_time, end_time = utils.parse_date_offset(f"LAST {days} DAYS")
+
+        start_time, _, _ = start_time.partition(".")
+        start_time = f"{start_time}Z"
+
+        end_time, _, _ = end_time.partition(".")
+        end_time = f"{end_time}Z"
+
+    return {
+        "StartTimeRange": start_time,
+        "EndTimeRange": end_time,
+    }
+
+
+def _run_query(query, arguments, evaluator=None, ctx=None):
+    """Runs a LQL query and returns a dataframe with the results.
+
+    :param str query: The LQL query to run.
+    :param dict arguments: A dict containing the arguments to send to the LQL
+        evaluator.
+    :param str evaluator: Optional string with an evaluator ID.
+    :param obj ctx: An optional Lacework context object.
+    :return: A pandas DataFrame with the results from the query.
+    """
+    if not ctx:
+        raise ValueError("Unable to run query, no context available.")
+
+    client = ctx.client
+    if not client:
+        raise ValueError("Unable to run query, no client set.")
+
+    return client.queries.execute(
+        evaluator_id=evaluator, query_text=query, arguments=arguments)
+
+
+def _query_function(query_dict):
+    """Generates a function to query LQL from a query dictionary.
+
+    :param dict query_dict: A dictionary that contains the query as well
+        as additional parameters.
+
+    :return: A function that can be used to generate a LQL query.
+    """
+    def wrapper(
+            days=0, start_time="", end_time="", ctx=None,
+            help=False, **kwargs):
+        """Query LQL and return back a DataFrame with the discovered content.
+
+        :param int days: Number of days to query back in time.
+        :param str start_time: ISO formatted timestamp of the start time of
+            the query. Optional and not needed if days is defined.
+        :param str end_time: ISO formatted timestamp of the end time of
+            the query. Optional and not needed if days is defined.
+        :param bool help: Defaults to False, if set to True the query
+            is not run and a dataframe with the parameters required is
+            returned back.
+        :param dict kwargs: Optional parameters that depend on each
+            specific search query. To understand what parameters are
+            required to be passed on for each query function call
+            the function with just the parameter help=True.
+        """
+        query = query_dict.get("query", "")
+        if not query:
+            raise ValueError("There is no query defined.")
+
+        params = query_dict.get('params', [])
+        if help:
+            return pd.DataFrame(params)
+
+        if not days and not (start_time and end_time):
+            raise ValueError(
+                "The parameters days, or both start_time and end_time need "
+                "to be defined.")
+
+        param_dict = {}
+        for parameter in params:
+            # TODO: Add type checking.
+            param_name = parameter.get("name", "__not_exists__")
+            # TOOD: Add to docstring.
+            if param_name not in kwargs:
+                raise ValueError(
+                    "Unable to run, missing parameter: {0:s}".format(
+                        param_name))
+            param_dict[param_name] = kwargs.get(param_name)
+
+        # Prepare the query for format strings.
+        query = query.replace("{", "{{").replace("}", "}}")
+        query = query.replace("<<", "{").replace(">>", "}")
+        query = query.format(**param_dict)
+        query = query.replace("{{", "{").replace("}}", "}")
+
+        arguments = _get_arguments(
+            days=days, start_time=start_time, end_time=end_time)
+        evaluator = query_dict.get("evaluator")
+
+        return _run_query(
+            query=query, evaluator=evaluator,
+            arguments=arguments, ctx=ctx)
+    return wrapper
+
+
+query_feature_directory = os.path.dirname(__file__)
+query_yaml_path = os.path.join(query_feature_directory, 'query.yaml')
+
+if os.path.isfile(query_yaml_path):
+    with open(query_yaml_path, 'r') as fh:
+        data = yaml.safe_load(fh)
+        for query_dict in data.get('queries', []):
+            name = query_dict.get("name", "")
+            function_name = f"query_{name}"
+            function_fn = _query_function(query_dict)
+
+            manager.LaceworkManager.add_feature(function_fn, function_name)

--- a/jupyter/laceworkjupyter/features/query.py
+++ b/jupyter/laceworkjupyter/features/query.py
@@ -57,6 +57,43 @@ def _run_query(query, arguments, evaluator=None, ctx=None):
         evaluator_id=evaluator, query_text=query, arguments=arguments)
 
 
+def _get_help_frame(parameters):
+    """
+    Returns a dataframe with the parameters for the query function.
+
+    :param list parameters: A list of dictionaries with the required extra
+        parameters the function requries.
+    :return: A dataframe with all the parameters listed.
+    """
+    for parameter in parameters:
+        parameter["required"] = True
+        parameter["note"] = "For replacing values in the query itself."
+
+    parameters.append({
+        "name": "days",
+        "type": "int",
+        "required": False,
+        "note": (
+            "Number of days to search back in time, end day is now. "
+            "Required to either provide days or both start and end time.")
+    })
+
+    parameters.append({
+        "name": "start_time",
+        "type": "str",
+        "required": False,
+        "note": "Start time expressed as an ISO formatted string."
+    })
+    parameters.append({
+        "name": "end_time",
+        "type": "str",
+        "required": False,
+        "note": "End time expressed as an ISO formatted string."
+    })
+
+    return pd.DataFrame(parameters)
+
+
 def _query_function(query_dict):
     """
     Generates a function to query LQL from a query dictionary.
@@ -91,7 +128,7 @@ def _query_function(query_dict):
 
         params = query_dict.get("params", [])
         if help:
-            return pd.DataFrame(params)
+            return _get_help_frame(params)
 
         if not days and not (start_time and end_time):
             raise ValueError(

--- a/jupyter/laceworkjupyter/features/query.yaml
+++ b/jupyter/laceworkjupyter/features/query.yaml
@@ -1,0 +1,94 @@
+---
+queries:
+    - name: "api_source_ip"
+      evaluator: "Cloudtrail"
+      params:
+        - name: "ip_address"
+          type: "str"
+      query: |-
+        APICheckIpSource {
+          SOURCE {
+              CloudTrailRawEvents
+          }
+          FILTER {
+            EVENT:sourceIPAddress = '<<ip_address>>'
+            AND ERROR_CODE IS NULL
+          }
+          RETURN DISTINCT {
+            INSERT_ID,
+            INSERT_TIME,
+            EVENT_TIME,
+            EVENT
+          }
+        }
+
+    - name: "agent_ip"
+      params:
+        - name: "ip_address"
+          type: "str"
+      query: |-
+        TestAgentConnections{
+          SOURCE {
+            LW_HA_CONNECTIONS
+          }
+          FILTER {
+            SRC_IP_ADDR = '<<ip_address>>'
+            OR DST_IP_ADDR = '<<ip_address>>'
+          }
+          RETURN DISTINCT {
+            MID,
+            SRC_IP_ADDR,
+            SRC_PORT,
+            DST_IP_ADDR,
+            DST_PORT,
+            PROTOCOL,
+            SYN,
+            INCOMING,
+            OUTGOING,
+            FIRST_KNOWN_TIME
+          }
+        }
+
+    - name: "dns_to_ip"
+      params:
+        - name: "ip_address"
+          type: "str"
+      query: |-
+        Test_DNS_Resolution {
+          SOURCE {
+            LW_HA_DNS_REQUESTS
+          }
+          FILTER {
+            HOST_IP_ADDR = '<<ip_address>>'
+          }
+          RETURN DISTINCT {
+            MID,
+            SRV_IP_ADDR,
+            HOSTNAME,
+            HOST_IP_ADDR,
+            TTL,
+            PKTLEN
+          }
+        }
+
+    - name: "dns_to_hostname"
+      params:
+        - name: "hostname"
+          type: "str"
+      query: |-
+        Test_DNS_Resolution {
+          SOURCE {
+            LW_HA_DNS_REQUESTS
+          }
+          FILTER {
+            HOSTNAME LIKE '%<<hostname>>%'
+          }
+          RETURN DISTINCT {
+            MID,
+            SRV_IP_ADDR,
+            HOSTNAME,
+            HOST_IP_ADDR,
+            TTL,
+            PKTLEN
+          }
+        }

--- a/jupyter/laceworkjupyter/helper.py
+++ b/jupyter/laceworkjupyter/helper.py
@@ -1,0 +1,73 @@
+import logging
+import os
+
+from laceworksdk import LaceworkClient
+
+from . import config
+from . import decorators
+from . import plugins
+
+
+logger = logging.getLogger('lacework_sdk.jupyter.helper')
+
+
+class APIWrapper:
+    """
+    API Wrapper class that takes an API wrapper and decorates functions.
+    """
+
+    def __init__(self, api_wrapper, wrapper_name):
+        self._api_wrapper = api_wrapper
+        self._api_name = wrapper_name
+
+        for func_name in [f for f in dir(api_wrapper) if not f.startswith('_')]:
+            func = getattr(api_wrapper, func_name)
+
+            decorator_plugin = plugins.PLUGINS.get(
+                f"{self._api_name}.{func_name}")
+            if decorator_plugin:
+                setattr(
+                    self,
+                    func_name,
+                    decorators.plugin_decorator(func, decorator_plugin))
+            else:
+                setattr(self, func_name, decorators.dataframe_decorator(func))
+
+
+class LaceworkJupyterClient:
+    """
+    Lacework API client wrapped up for Jupyter usage.
+
+    This is a simple class that acts as a Jupyter wrapper around the
+    Python Lacework SDK. It simply wraps the SDK functions to return
+    a DataFrame instead of a dict when calling API functions.
+    """
+
+    def __init__(
+            self, api_key=None, api_secret=None, account=None,
+            subaccount=None, instance=None, base_domain=None,
+            profile=None):
+
+        self.sdk = LaceworkClient(
+            api_key=api_key, api_secret=api_secret,
+            account=account, subaccount=subaccount,
+            instance=instance, base_domain=base_domain,
+            profile=profile)
+
+        wrappers = [w for w in dir(self.sdk) if not w.startswith('_')]
+        for wrapper in wrappers:
+            wrapper_object = getattr(self.sdk, wrapper)
+            api_wrapper = APIWrapper(wrapper_object, wrapper_name=wrapper)
+            setattr(self, wrapper, api_wrapper)
+
+    def __enter__(self):
+        """
+        Support the with statement in python.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Support the with statement in python.
+        """
+        pass

--- a/jupyter/laceworkjupyter/helper.py
+++ b/jupyter/laceworkjupyter/helper.py
@@ -8,7 +8,7 @@ from . import decorators
 from . import plugins
 
 
-logger = logging.getLogger('lacework_sdk.jupyter.helper')
+logger = logging.getLogger("lacework_sdk.jupyter.helper")
 
 
 class APIWrapper:
@@ -20,7 +20,7 @@ class APIWrapper:
         self._api_wrapper = api_wrapper
         self._api_name = wrapper_name
 
-        for func_name in [f for f in dir(api_wrapper) if not f.startswith('_')]:
+        for func_name in [f for f in dir(api_wrapper) if not f.startswith("_")]:
             func = getattr(api_wrapper, func_name)
 
             decorator_plugin = plugins.PLUGINS.get(
@@ -54,7 +54,7 @@ class LaceworkJupyterClient:
             instance=instance, base_domain=base_domain,
             profile=profile)
 
-        wrappers = [w for w in dir(self.sdk) if not w.startswith('_')]
+        wrappers = [w for w in dir(self.sdk) if not w.startswith("_")]
         for wrapper in wrappers:
             wrapper_object = getattr(self.sdk, wrapper)
             api_wrapper = APIWrapper(wrapper_object, wrapper_name=wrapper)

--- a/jupyter/laceworkjupyter/helper.py
+++ b/jupyter/laceworkjupyter/helper.py
@@ -1,9 +1,7 @@
 import logging
-import os
 
 from laceworksdk import LaceworkClient
 
-from . import config
 from . import decorators
 from . import plugins
 

--- a/jupyter/laceworkjupyter/manager.py
+++ b/jupyter/laceworkjupyter/manager.py
@@ -39,5 +39,3 @@ class LaceworkManager:
         """
         for feature_fn, feature_name in cls._features.items():
             yield (feature_name, feature_fn)
-
-

--- a/jupyter/laceworkjupyter/manager.py
+++ b/jupyter/laceworkjupyter/manager.py
@@ -1,0 +1,43 @@
+"""A manager that manages various plugins in the helper."""
+
+
+class LaceworkManager:
+    """Simple plugin management class."""
+
+    # Dictionaries holding the registered functions.
+    _plugins = {}
+    _features = {}
+
+    @classmethod
+    def add_feature(cls, feature_fn, feature_name):
+        """
+        Add a feature to the registration.
+
+        :param func feature_fn: The function to be registered.
+        :param str feature_name: The name of the function.
+        :raises ValueError: If the function is already registered.
+        """
+        feature_name = feature_name.lower()
+
+        if feature_name == 'ctx':
+            raise ValueError(
+                'Feature ctx is a reserved name for a feature.')
+
+        if feature_name in cls._features:
+            raise ValueError(
+                'Feature {0:s} is already registered as a feature.'.format(
+                    feature_name))
+        cls._features[feature_name] = feature_fn
+
+    @classmethod
+    def get_features(cls):
+        """
+        Yields a tuple with the feature function and name.
+
+        :yields: A tuple two items, feature function and feature name.
+            A tuple is yielded for each registered feature in the system.
+        """
+        for feature_fn, feature_name in cls._features.items():
+            yield (feature_name, feature_fn)
+
+

--- a/jupyter/laceworkjupyter/utils.py
+++ b/jupyter/laceworkjupyter/utils.py
@@ -31,7 +31,7 @@ def dataframe_decorator(function):
     return get_output
 
 
-def flatten_json_output(json_data, pre_key='', lists_to_rows=False):
+def flatten_json_output(json_data, pre_key='', lists_to_rows=False):  # noqa: C901
     """
     Flatten and yield dict objects from a Lacework JSON structure.
 
@@ -125,7 +125,7 @@ def flatten_data_frame(data_frame, lists_to_rows=False):
     return pd.DataFrame(rows)
 
 
-def parse_date_offset(offset_string):
+def parse_date_offset(offset_string):  # noqa: C901
     """
     Parse date offset string and return a start and end time.
 

--- a/jupyter/laceworkjupyter/version.py
+++ b/jupyter/laceworkjupyter/version.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 
 def get_version():

--- a/jupyter/notebooks/colab_sample.ipynb
+++ b/jupyter/notebooks/colab_sample.ipynb
@@ -82,7 +82,7 @@
         "id": "5db5b5ad"
       },
       "source": [
-        "client = LaceworkJupyterHelper()"
+        "client = lw.get_client()"
       ],
       "id": "5db5b5ad",
       "execution_count": null,
@@ -97,7 +97,7 @@
         "If you need to manually enter the credentials you can run the above cell using the parameters:\n",
         "\n",
         "```\n",
-        "client = LaceworkJupyterHelper(\n",
+        "client = lw.get_client(\n",
         "    api_key=API_KEY,\n",
         "    api_secret=API_SECRET,\n",
         "    account=ACCOUNT,\n",

--- a/jupyter/requirements.txt
+++ b/jupyter/requirements.txt
@@ -1,2 +1,3 @@
 laceworksdk>=0.9.23
 pandas>=1.0.1
+pyyaml>=5.4.1

--- a/jupyter/setup.py
+++ b/jupyter/setup.py
@@ -5,43 +5,44 @@ from setuptools import find_packages, setup
 from laceworkjupyter import version
 
 
-PACKAGE_NAME = 'laceworkjupyter'
+PACKAGE_NAME = "laceworkjupyter"
 
 project_root = os.path.abspath(os.path.dirname(__file__))
 
 # Read the contents of README.md file
-with open(os.path.join(project_root, 'README.md'), encoding='utf-8') as f:
+with open(os.path.join(project_root, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name='laceworkjupyter',
-    packages=find_packages(include=['laceworkjupyter', 'laceworkjupyter.*']),
-    license='MIT',
-    description='Community-developed Jupyter helper for the Lacework Python SDK',
+    name="laceworkjupyter",
+    packages=find_packages(include=["laceworkjupyter", "laceworkjupyter.*"]),
+    license="MIT",
+    description="Community-developed Jupyter helper for the Lacework Python SDK",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    author='Kristinn Gudjonsson',
-    author_email='kristinn.gudjonsson@lacework.net',
+    long_description_content_type="text/markdown",
+    author="Kristinn Gudjonsson",
+    author_email="kristinn.gudjonsson@lacework.net",
     version=version.get_version(),
-    url='https://github.com/lacework/python-sdk',
-    download_url='https://pypi.python.org/pypi/laceworkjupyter',
-    keywords=['lacework', 'api', 'sdk', 'python', 'api', 'jupyter', 'notebook'],
+    url="https://github.com/lacework/python-sdk",
+    download_url="https://pypi.python.org/pypi/laceworkjupyter",
+    keywords=["lacework", "api", "sdk", "python", "api", "jupyter", "notebook"],
     include_package_data=True,
     install_requires=[
-        'python-dotenv',
-        'requests',
-        'laceworksdk',
-        'pandas'
+        "python-dotenv",
+        "requests",
+        "pyyaml",
+        "laceworksdk",
+        "pandas"
     ],
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Build Tools',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Build Tools",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )

--- a/jupyter/setup.py
+++ b/jupyter/setup.py
@@ -26,6 +26,7 @@ setup(
     url='https://github.com/lacework/python-sdk',
     download_url='https://pypi.python.org/pypi/laceworkjupyter',
     keywords=['lacework', 'api', 'sdk', 'python', 'api', 'jupyter', 'notebook'],
+    include_package_data=True,
     install_requires=[
         'python-dotenv',
         'requests',

--- a/laceworksdk/api/policies.py
+++ b/laceworksdk/api/policies.py
@@ -127,7 +127,7 @@ class PoliciesAPI(object):
 
         return self.get(policy_id=policy_id, org=org)
 
-    def update(self,
+    def update(self,  # noqa: C901
                policy_id,
                policy_type=None,
                query_id=None,


### PR DESCRIPTION
Made quite a few changes to the Jupyter notebook assistant:

- Adding a Lacework ctx (context) that is passed along if needed
- Adding a manager to better handle registration of new helper functions
- Moved the SDK wrapper to a separate client file
- The new main touching point of the notebook is an object that contains a context and can call functions or features
- Adding a new concept of `features`, which ties to the main notebook object that provides additional functionality
- Added two features, one for getting a new client and the other to run pre-defined LQL queries to gather more context
- Updated the notebook container to take advantage of these new features