### PR TITLE
Made the evaluator ID optional for policies.

### DIFF
--- a/laceworksdk/api/policies.py
+++ b/laceworksdk/api/policies.py
@@ -33,7 +33,7 @@ class PoliciesAPI(object):
                severity,
                alert_enabled,
                alert_profile,
-               evaluator_id,
+               evaluator_id=None,
                limit=None,
                eval_frequency=None,
                org=False):
@@ -75,8 +75,9 @@ class PoliciesAPI(object):
             "severity": severity,
             "alertEnabled": int(bool(alert_enabled)),
             "alertProfile": alert_profile,
-            "evaluatorId": evaluator_id
         }
+        if evaluator_id:
+            data["evaluatorId"] = evaluator_id
 
         if isinstance(limit, int) and limit >= 0:
             data["limit"] = limit


### PR DESCRIPTION
Similar to what was done in queries, we need to make the evaluator_id optional.