### PR TITLE
Made changes to the Mitre ATT&CK Integration

### DIFF
--- a/jupyter/laceworkjupyter/features/mitre.yaml
+++ b/jupyter/laceworkjupyter/features/mitre.yaml
@@ -1,5 +1,21 @@
-- mitre_id: T1204
-  alertType: SuspiciousApplicationLaunched
+- alert_fields: 
+    - name: alertType
+      value: NewUser
+      type: exact
+  id: T1136.003
 
-- mitre_id: T1531
-  alertType: NetworkSecurityGroupCreatedOrUpdated
+- alert_fields:
+    - name: alertType
+      value: MaliciousFile
+      type: exact
+  id: T1204.002
+
+- alert_fields:
+    - name: alertType
+      value: SuspiciousApplicationLaunched
+      type: exact
+    - name: keys.src.keys.exe_path
+      value: python
+      type: contains
+  condition: and
+  id: T1059.006


### PR DESCRIPTION
This PR makes considerably changes to the Mitre ATT&CK integration. It extends the support of the YAML file to include more flexible matching between Mitre IDs and ATT&CK techniques.

Instead of having a simple 1:1 matching between alertType it is now flexible which column to choose, and you can combine the content of multiple columns to generate the filter for the matching.