### PR TITLE
fix: sanitize the provided account name

### DIFF
--- a/laceworksdk/http_session.py
+++ b/laceworksdk/http_session.py
@@ -53,6 +53,11 @@ class HttpSession:
         self._api_key = api_key
         self._api_secret = api_secret
         self._base_domain = base_domain or DEFAULT_BASE_DOMAIN
+
+        domain_string = f".{self._base_domain}"
+        if account.endswith(domain_string):
+            account = account[:-len(domain_string)]
+
         self._base_url = f"https://{account}.{self._base_domain}"
         self._subaccount = subaccount
         self._org_level_access = False


### PR DESCRIPTION
This PR is meant to resolve #72 - This will remove the base domain if it was provided with the `account` parameter.  This prevents duplication of the base domain which would result in DNS resolution issues during initialization.