### PR TITLE
(fix) fixed and issue for subclasses containing API calls in Jupyter notebook

### DIFF
--- a/jupyter/laceworkjupyter/plugins/alerts.py
+++ b/jupyter/laceworkjupyter/plugins/alerts.py
@@ -3,8 +3,6 @@
 
 import pandas as pd
 
-from laceworkjupyter.features import helper
-
 
 def process_alerts(data):
     """

--- a/tests/api/v2/test_vulnerability_policies.py
+++ b/tests/api/v2/test_vulnerability_policies.py
@@ -3,7 +3,6 @@
 Test suite for the community-developed Python SDK for interacting with Lacework APIs.
 """
 
-from ast import operator
 import pytest
 
 from laceworksdk.api.v2.vulnerability_policies import VulnerabilityPoliciesAPI


### PR DESCRIPTION
Fixed an issue in API V2 where APIs are subclasses of other classes, eg `.activities.dns`, etc... this PR makes sure to traverse the sub classes as well, one layer deeper to register the API wrapper accordingly.