### PR TITLE
(fix) a bug in TS API client prevents the notebook from loading.

### DIFF
--- a/jupyter/docker/docker_build/00-import.py
+++ b/jupyter/docker/docker_build/00-import.py
@@ -14,14 +14,16 @@ from laceworkjupyter.helper import LaceworkJupyterClient as LaceworkJupyterHelpe
 import snowflake.connector
 
 # Import forensic tools designed for notebooks.
-from picatrix import notebook_init
+# TODO (kiddi): Re-enable once TS API has been fiex, see #2388 on Timesketch.
+#from picatrix import notebook_init
 import ds4n6_lib as ds
 
 # Add in the accessors to pandas.
 from laceworkjupyter import accessors
 
 # Enable the Picatrix helpers.
-notebook_init.init()
+# TODO (kiddi): Re-enable once TS is fixed, see above.
+#notebook_init.init()
 
 # Enable the LW object.
 lw = laceworkjupyter.LaceworkHelper()


### PR DESCRIPTION
The TS API client has not yet upgraded the now deprecated OOB flow in Oauth, causing it to fail when attempting to import, and therefore having cascading effects on the jupyter notebook environment (which loads the TS client as part of other libraries)... disabling the dependencies for now

TS bug: https://github.com/google/timesketch/issues/2388 