### PR TITLE
feat: making it easer to see and set subaccounts

### DIFF
--- a/jupyter/laceworkjupyter/helper.py
+++ b/jupyter/laceworkjupyter/helper.py
@@ -76,6 +76,19 @@ class LaceworkJupyterClient:
             else:
                 setattr(self, wrapper, wrapper_object)
 
+    @property
+    def subaccount(self):
+        """Returns the subaccount that is in use."""
+        return self.sdk.subaccount
+
+    @subaccount.setter
+    def subaccount(self, subaccount):
+        """Changes the subaccount that is in use."""
+        if subaccount == self.subaccount:
+            return
+
+        self.sdk.set_subaccount(subaccount)
+
     def __enter__(self):
         """
         Support the with statement in python.

--- a/laceworksdk/api/__init__.py
+++ b/laceworksdk/api/__init__.py
@@ -178,6 +178,13 @@ class LaceworkClient:
         self.vulnerability_exceptions = VulnerabilityExceptionsAPI(self._session)
         self.vulnerability_policies = VulnerabilityPoliciesAPI(self._session)
 
+    @property
+    def subaccount(self):
+        """
+        Returns the value of the session's subaccount.
+        """
+        return self._session.subaccount
+
     def set_org_level_access(self, org_level_access):
         """
         A method to set whether the client should use organization-level API calls.
@@ -193,4 +200,4 @@ class LaceworkClient:
         A method to update the subaccount the client should use for API calls.
         """
 
-        self._session._subaccount = subaccount
+        self._session.subaccount = subaccount

--- a/laceworksdk/http_session.py
+++ b/laceworksdk/http_session.py
@@ -266,6 +266,20 @@ class HttpSession:
 
         return response
 
+    @property
+    def subaccount(self):
+        """
+        Returns the current subaccount for the session.
+        """
+        return self._subaccount
+
+    @subaccount.setter
+    def subaccount(self, subaccount):
+        """
+        Modifies the value of the sessions's subaccount.
+        """
+        self._subaccount = subaccount
+
     def get(self, uri, params=None, **kwargs):
         """
         A method to build a GET request to interact with Lacework.


### PR DESCRIPTION
Making subaccounts more easily visible in the HTTP session, API client as well as in the jupyter client.

ATM some of this is done today by using access to private variables within classes, which is not an ideal way of doing things, this way the classes expose the subaccount intentionally as a property, that can be modified