### PR TITLE
(fix) a bug where subaccounts got set on the jupyter object.

### DIFF
--- a/jupyter/laceworkjupyter/helper.py
+++ b/jupyter/laceworkjupyter/helper.py
@@ -56,6 +56,9 @@ class LaceworkJupyterClient:
 
         wrappers = [w for w in dir(self.sdk) if not w.startswith("_")]
         for wrapper in wrappers:
+            if wrapper == 'subaccount':
+                continue
+
             wrapper_object = getattr(self.sdk, wrapper)
             api_wrapper = APIWrapper(wrapper_object, wrapper_name=wrapper)
 


### PR DESCRIPTION
After the subaccount property was added to the SDK the jupyter wrapper now stores the api wrapper object as a property of the helper, this is a fix to make sure we don't do that.