### PR TITLE
fix: moving account validation to SDK object instantiation

### DIFF
--- a/laceworksdk/api/__init__.py
+++ b/laceworksdk/api/__init__.py
@@ -127,6 +127,10 @@ class LaceworkClient:
                 if not self._subaccount and subaccount:
                     self._subaccount = subaccount
 
+        domain_string = f".{self._base_domain}"
+        if self._account.endswith(domain_string):
+            self._account = self._account[:-len(domain_string)]
+
         # Create an HttpSession instance
         self._session = HttpSession(
             self._account,

--- a/laceworksdk/http_session.py
+++ b/laceworksdk/http_session.py
@@ -54,11 +54,8 @@ class HttpSession:
         self._api_secret = api_secret
         self._base_domain = base_domain or DEFAULT_BASE_DOMAIN
 
-        domain_string = f".{self._base_domain}"
-        if account.endswith(domain_string):
-            account = account[:-len(domain_string)]
-
         self._base_url = f"https://{account}.{self._base_domain}"
+        self._account = account
         self._subaccount = subaccount
         self._org_level_access = False
 
@@ -265,6 +262,13 @@ class HttpSession:
                 response._content = b'{"data": []}'
 
         return response
+
+    @property
+    def account(self):
+        """
+        Returns the current account for the session.
+        """
+        return self._account
 
     @property
     def subaccount(self):


### PR DESCRIPTION
This PR moves the `account` parameter validation to the instantiation of the `laceworksdk` object, rather than doing it in the http session.