### PR TITLE
fix: pagination updates for the alerts endpoint

### DIFF
--- a/laceworksdk/api/v2/alerts.py
+++ b/laceworksdk/api/v2/alerts.py
@@ -22,7 +22,7 @@ class AlertsAPI(SearchEndpoint):
     def get(self,
             start_time=None,
             end_time=None,
-            limit=500,
+            limit=None,
             **request_params):
         """
         A method to get Alerts objects.
@@ -30,7 +30,6 @@ class AlertsAPI(SearchEndpoint):
         :param start_time: A "%Y-%m-%dT%H:%M:%SZ" structured timestamp to begin from.
         :param end_time: A "%Y-%m-%dT%H:%M:%S%Z" structured timestamp to end at.
         :param limit: An integer representing the number of Alerts to return.
-            (Default is 500 / Maximum is 500,000)
         :param request_params: Additional request parameters.
             (provides support for parameters that may be added in the future)
 
@@ -45,17 +44,22 @@ class AlertsAPI(SearchEndpoint):
 
         response = self._session.get(self.build_url(), params=params)
 
-        response_data = {"data": []}
+        return_data = {"data": []}
         current_rows = 0
 
         while True:
             response_json = response.json()
 
-            take = limit - current_rows
-            response_data["data"].extend(response_json["data"][:take])
-            current_rows = len(response_data["data"])
+            return_data["paging"] = response_json["paging"]
 
-            if current_rows >= limit:
+            if limit:
+                take = limit - current_rows
+                return_data["data"].extend(response_json["data"][:take])
+            else:
+                return_data["data"].extend(response_json["data"])
+            current_rows = len(return_data["data"])
+
+            if limit and current_rows >= limit:
                 break
 
             try:
@@ -68,7 +72,7 @@ class AlertsAPI(SearchEndpoint):
             else:
                 break
 
-        return response_data
+        return return_data
 
     def get_details(self,
                     id,

--- a/laceworksdk/api/v2/alerts.py
+++ b/laceworksdk/api/v2/alerts.py
@@ -39,10 +39,19 @@ class AlertsAPI(SearchEndpoint):
             start_time=start_time,
             end_time=end_time
         )
-
+        results = {'data':[]}
         response = self._session.get(self.build_url(), params=params)
-
-        return response.json()
+        while True:
+            response_json = response.json()
+            results['paging'] = response_json['paging']
+            results['data'].extend(response_json['data'])
+            next_page_url = response_json['paging']['urls']['nextPage']
+            if next_page_url:
+                response = self._session.get(next_page_url, params=params)
+            else:
+                break
+        results['paging']['rows'] = results['paging']['totalRows']
+        return results
 
     def get_details(self,
                     id,


### PR DESCRIPTION
Hey @tmac1973!  Thanks for proposing a PR for this - if my memory serves, this endpoint was originally released without pagination.  So, as you correctly pointed out, I was hesitant to migrate it to the paginated endpoint  of returning a generator simply to prevent breaking changes.

I made some slight changes to your PR so that there's an imposed limit on the alerts by default.  This should mean that the functionality wont change for any previous implementations, but still allows the user to specify a higher upper-bound.  Two main reasons I'd like to do things this way:
- If there are a lot of results, it can take a long time to iterate through many pages.
- The dataset that gets returned can become pretty massive.

Happy to consider a higher default if you think it's necessary.