### PR TITLE
fix: modified create policy wrapper to use type bool instead of int for 'enabled' field

### DIFF
--- a/laceworksdk/api/v2/policies.py
+++ b/laceworksdk/api/v2/policies.py
@@ -71,7 +71,7 @@ class PoliciesAPI(CrudEndpoint):
         return super().create(
             policy_type=policy_type,
             query_id=query_id,
-            enabled=int(bool(enabled)),
+            enabled=enabled,
             title=title,
             description=description,
             remediation=remediation,


### PR DESCRIPTION
Removed the `int` and `bool` type casts from the `enabled` field when creating a new policy in the `policies.py` wrapper.

In response to error when passing type `int` when creating a new policy:
```laceworksdk.exceptions.ApiError: [400] Bad Request - Problem parsing JSON, the value for key enabled is of the wrong type```