### PR TITLE
feat(http_session): add opt. requests timeout parameter

### DIFF
--- a/laceworksdk/api/__init__.py
+++ b/laceworksdk/api/__init__.py
@@ -70,7 +70,8 @@ class LaceworkClient:
                  api_secret=None,
                  instance=None,
                  base_domain=None,
-                 profile=None):
+                 profile=None,
+                 http_client_timeout=None):
         """
         Initializes the Lacework Client object.
 
@@ -131,7 +132,8 @@ class LaceworkClient:
             self._subaccount,
             self._api_key,
             self._api_secret,
-            self._base_domain
+            self._base_domain,
+            http_client_timeout
         )
 
         # API Wrappers

--- a/laceworksdk/http_session.py
+++ b/laceworksdk/http_session.py
@@ -20,6 +20,7 @@ from laceworksdk.config import (
 from laceworksdk.exceptions import ApiError, MalformedResponse, RateLimitError
 
 logger = logging.getLogger(__name__)
+HTTP_REQUEST_DEFAULT_TIMEOUT_SEC = 30
 
 
 class HttpSession:
@@ -30,7 +31,7 @@ class HttpSession:
     _access_token = None
     _access_token_expiry = None
 
-    def __init__(self, account, subaccount, api_key, api_secret, base_domain):
+    def __init__(self, account, subaccount, api_key, api_secret, base_domain, http_timeout=None):
         """
         Initializes the HttpSession object.
 
@@ -39,6 +40,7 @@ class HttpSession:
         :param api_key: a Lacework API Key
         :param api_secret: a Lacework API Secret
         :param base_domain: a Lacework Domain (defaults to "lacework.net")
+        :param timeout: a client timeout for every HTTP request
 
         :return HttpSession object.
         """
@@ -52,6 +54,7 @@ class HttpSession:
         self._api_key = api_key
         self._api_secret = api_secret
         self._base_domain = base_domain
+        self._timeout = http_timeout or HTTP_REQUEST_DEFAULT_TIMEOUT_SEC
 
         self._base_url = f"https://{account}.{self._base_domain}"
         self._account = account
@@ -164,7 +167,7 @@ class HttpSession:
         response = None
 
         try:
-            response = self._session.post(uri, json=data, headers=headers)
+            response = self._session.post(uri, json=data, headers=headers, timeout=self._timeout)
 
             # Validate the response
             self._check_response_code(response, DEFAULT_SUCCESS_RESPONSE_CODES)
@@ -249,7 +252,7 @@ class HttpSession:
             kwargs.pop("data")
 
         # Make the HTTP request to the API endpoint
-        response = self._session.request(method, uri, headers=headers, **kwargs)
+        response = self._session.request(method, uri, headers=headers, timeout=self._timeout, **kwargs)
 
         # Validate the response
         self._check_response_code(response, DEFAULT_SUCCESS_RESPONSE_CODES)


### PR DESCRIPTION
Users can now specify after how much time a request should timeout. This new parameter will prevent the default "hang forever" behaviour `requests` has.

The idea here is that if the user feels like it's taking to long, they can change strategy or fail faster (even if the service would eventually respond).

This comes from a problem we faced using the Lacework `python-sdk` where a request took 8 minutes to finally give us a 504. It's not the end of the world, but this could be an easy, free fix.

Cheers!
