### PR TITLE
test: fix slack alerting and mark some tests as flakey

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -61,6 +61,6 @@ jobs:
           notify_when: "failure"
           notification_title: "{workflow} has {status_message}"
           message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
-          footer: "Linked Repo <{repo_url}|{repo}> | <{workflow_url}|View Workflow>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/tests/api/v2/test_alert_channels.py
+++ b/tests/api/v2/test_alert_channels.py
@@ -82,3 +82,7 @@ class TestAlertChannelsOrg(TestAlertChannels):
     @pytest.mark.flaky_test
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)
+
+    @pytest.mark.flaky_test
+    def test_api_get_by_type(self, api_object):
+        self._get_object_classifier_test(api_object, "type")

--- a/tests/api/v2/test_alert_channels.py
+++ b/tests/api/v2/test_alert_channels.py
@@ -48,6 +48,7 @@ class TestAlertChannels(CrudEndpoint):
     OBJECT_ID_NAME = "intgGuid"
     OBJECT_TYPE = AlertChannelsAPI
 
+    @pytest.mark.flaky_test
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)
 

--- a/tests/api/v2/test_alert_channels.py
+++ b/tests/api/v2/test_alert_channels.py
@@ -78,4 +78,7 @@ class TestAlertChannels(CrudEndpoint):
 
 @pytest.mark.parametrize("api_object", [pytest.lazy_fixture("api_object_org")])
 class TestAlertChannelsOrg(TestAlertChannels):
-    pass
+
+    @pytest.mark.flaky_test
+    def test_api_get_by_guid(self, api_object):
+        self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_resource_groups.py
+++ b/tests/api/v2/test_resource_groups.py
@@ -47,5 +47,6 @@ class TestResourceGroups(CrudEndpoint):
     OBJECT_TYPE = ResourceGroupsAPI
     OBJECT_PARAM_EXCEPTIONS = ["props"]
 
+    @pytest.mark.flaky_test
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)


### PR DESCRIPTION
Summary:

Slack alert did not include link to workflow run. 

ResourceGroupV2  beta flag is turned on in techally test environment causing one of those tests to fail. Marking that test as "flakey" for now. Opening separate issue to fix

Some AlertChannel test are failing randomly with a 404. Marking "flakey" for now and opening separate issue to investigate. 

Issue:

https://lacework.atlassian.net/browse/GROW-2297