### PR TITLE
test: fix race condition with delete tests

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,50 @@
+name: Run Python Linting/Docstring Linting
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 8 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install poetry
+        run: |
+          pipx install poetry
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
+
+      - name: Install dependencies
+        run: |
+          poetry install
+
+      - name: Lint Docstrings with ruff
+        run: |
+          poetry run poe lint-docstrings 
+
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          poetry run poe lint
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          poetry run flake8 . --exclude "jupyter" --count --exit-zero --max-complexity=10 --statistics
+

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -53,14 +53,14 @@ jobs:
           LW_API_KEY: ${{ secrets.LW_API_KEY }}
           LW_API_SECRET: ${{ secrets.LW_API_SECRET }}
           LW_BASE_DOMAIN: ${{ secrets.LW_BASE_DOMAIN }}
-      - name: Report Status
-        if: always()
-        uses: ravsamhq/notify-slack-action@v2
-        with:
-          status: ${{ job.status }}
-          notify_when: "failure"
-          notification_title: "{workflow} has {status_message}"
-          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
-          footer: "Linked Repo <{repo_url}|{repo}> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#      - name: Report Status
+#        if: always()
+#        uses: ravsamhq/notify-slack-action@v2
+#        with:
+#          status: ${{ job.status }}
+#          notify_when: "failure"
+#          notification_title: "{workflow} has {status_message}"
+#          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+#          footer: "Linked Repo <{repo_url}|{repo}> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -289,13 +289,13 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "7.0.0"
+version = "7.0.1"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-7.0.0-py3-none-any.whl", hash = "sha256:d97503976bb81f40a193d41ee6570868479c69d5068651eb039c40d850c59d67"},
-    {file = "importlib_metadata-7.0.0.tar.gz", hash = "sha256:7fc841f8b8332803464e5dc1c63a2e59121f46ca186c0e2e182e80bf8c1319f7"},
+    {file = "importlib_metadata-7.0.1-py3-none-any.whl", hash = "sha256:4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e"},
+    {file = "importlib_metadata-7.0.1.tar.gz", hash = "sha256:f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc"},
 ]
 
 [package.dependencies]
@@ -416,38 +416,38 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.7.1"
+version = "1.8.0"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:12cce78e329838d70a204293e7b29af9faa3ab14899aec397798a4b41be7f340"},
-    {file = "mypy-1.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1484b8fa2c10adf4474f016e09d7a159602f3239075c7bf9f1627f5acf40ad49"},
-    {file = "mypy-1.7.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31902408f4bf54108bbfb2e35369877c01c95adc6192958684473658c322c8a5"},
-    {file = "mypy-1.7.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f2c2521a8e4d6d769e3234350ba7b65ff5d527137cdcde13ff4d99114b0c8e7d"},
-    {file = "mypy-1.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:fcd2572dd4519e8a6642b733cd3a8cfc1ef94bafd0c1ceed9c94fe736cb65b6a"},
-    {file = "mypy-1.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4b901927f16224d0d143b925ce9a4e6b3a758010673eeded9b748f250cf4e8f7"},
-    {file = "mypy-1.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2f7f6985d05a4e3ce8255396df363046c28bea790e40617654e91ed580ca7c51"},
-    {file = "mypy-1.7.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:944bdc21ebd620eafefc090cdf83158393ec2b1391578359776c00de00e8907a"},
-    {file = "mypy-1.7.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9c7ac372232c928fff0645d85f273a726970c014749b924ce5710d7d89763a28"},
-    {file = "mypy-1.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:f6efc9bd72258f89a3816e3a98c09d36f079c223aa345c659622f056b760ab42"},
-    {file = "mypy-1.7.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6dbdec441c60699288adf051f51a5d512b0d818526d1dcfff5a41f8cd8b4aaf1"},
-    {file = "mypy-1.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4fc3d14ee80cd22367caaaf6e014494415bf440980a3045bf5045b525680ac33"},
-    {file = "mypy-1.7.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c6e4464ed5f01dc44dc9821caf67b60a4e5c3b04278286a85c067010653a0eb"},
-    {file = "mypy-1.7.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:d9b338c19fa2412f76e17525c1b4f2c687a55b156320acb588df79f2e6fa9fea"},
-    {file = "mypy-1.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:204e0d6de5fd2317394a4eff62065614c4892d5a4d1a7ee55b765d7a3d9e3f82"},
-    {file = "mypy-1.7.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:84860e06ba363d9c0eeabd45ac0fde4b903ad7aa4f93cd8b648385a888e23200"},
-    {file = "mypy-1.7.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8c5091ebd294f7628eb25ea554852a52058ac81472c921150e3a61cdd68f75a7"},
-    {file = "mypy-1.7.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40716d1f821b89838589e5b3106ebbc23636ffdef5abc31f7cd0266db936067e"},
-    {file = "mypy-1.7.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5cf3f0c5ac72139797953bd50bc6c95ac13075e62dbfcc923571180bebb662e9"},
-    {file = "mypy-1.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:78e25b2fd6cbb55ddfb8058417df193f0129cad5f4ee75d1502248e588d9e0d7"},
-    {file = "mypy-1.7.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:75c4d2a6effd015786c87774e04331b6da863fc3fc4e8adfc3b40aa55ab516fe"},
-    {file = "mypy-1.7.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2643d145af5292ee956aa0a83c2ce1038a3bdb26e033dadeb2f7066fb0c9abce"},
-    {file = "mypy-1.7.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75aa828610b67462ffe3057d4d8a4112105ed211596b750b53cbfe182f44777a"},
-    {file = "mypy-1.7.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ee5d62d28b854eb61889cde4e1dbc10fbaa5560cb39780c3995f6737f7e82120"},
-    {file = "mypy-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:72cf32ce7dd3562373f78bd751f73c96cfb441de147cc2448a92c1a308bd0ca6"},
-    {file = "mypy-1.7.1-py3-none-any.whl", hash = "sha256:f7c5d642db47376a0cc130f0de6d055056e010debdaf0707cd2b0fc7e7ef30ea"},
-    {file = "mypy-1.7.1.tar.gz", hash = "sha256:fcb6d9afb1b6208b4c712af0dafdc650f518836065df0d4fb1d800f5d6773db2"},
+    {file = "mypy-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:485a8942f671120f76afffff70f259e1cd0f0cfe08f81c05d8816d958d4577d3"},
+    {file = "mypy-1.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:df9824ac11deaf007443e7ed2a4a26bebff98d2bc43c6da21b2b64185da011c4"},
+    {file = "mypy-1.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2afecd6354bbfb6e0160f4e4ad9ba6e4e003b767dd80d85516e71f2e955ab50d"},
+    {file = "mypy-1.8.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8963b83d53ee733a6e4196954502b33567ad07dfd74851f32be18eb932fb1cb9"},
+    {file = "mypy-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:e46f44b54ebddbeedbd3d5b289a893219065ef805d95094d16a0af6630f5d410"},
+    {file = "mypy-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:855fe27b80375e5c5878492f0729540db47b186509c98dae341254c8f45f42ae"},
+    {file = "mypy-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4c886c6cce2d070bd7df4ec4a05a13ee20c0aa60cb587e8d1265b6c03cf91da3"},
+    {file = "mypy-1.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d19c413b3c07cbecf1f991e2221746b0d2a9410b59cb3f4fb9557f0365a1a817"},
+    {file = "mypy-1.8.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9261ed810972061388918c83c3f5cd46079d875026ba97380f3e3978a72f503d"},
+    {file = "mypy-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:51720c776d148bad2372ca21ca29256ed483aa9a4cdefefcef49006dff2a6835"},
+    {file = "mypy-1.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:52825b01f5c4c1c4eb0db253ec09c7aa17e1a7304d247c48b6f3599ef40db8bd"},
+    {file = "mypy-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f5ac9a4eeb1ec0f1ccdc6f326bcdb464de5f80eb07fb38b5ddd7b0de6bc61e55"},
+    {file = "mypy-1.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afe3fe972c645b4632c563d3f3eff1cdca2fa058f730df2b93a35e3b0c538218"},
+    {file = "mypy-1.8.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:42c6680d256ab35637ef88891c6bd02514ccb7e1122133ac96055ff458f93fc3"},
+    {file = "mypy-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:720a5ca70e136b675af3af63db533c1c8c9181314d207568bbe79051f122669e"},
+    {file = "mypy-1.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:028cf9f2cae89e202d7b6593cd98db6759379f17a319b5faf4f9978d7084cdc6"},
+    {file = "mypy-1.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4e6d97288757e1ddba10dd9549ac27982e3e74a49d8d0179fc14d4365c7add66"},
+    {file = "mypy-1.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f1478736fcebb90f97e40aff11a5f253af890c845ee0c850fe80aa060a267c6"},
+    {file = "mypy-1.8.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:42419861b43e6962a649068a61f4a4839205a3ef525b858377a960b9e2de6e0d"},
+    {file = "mypy-1.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:2b5b6c721bd4aabaadead3a5e6fa85c11c6c795e0c81a7215776ef8afc66de02"},
+    {file = "mypy-1.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5c1538c38584029352878a0466f03a8ee7547d7bd9f641f57a0f3017a7c905b8"},
+    {file = "mypy-1.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4ef4be7baf08a203170f29e89d79064463b7fc7a0908b9d0d5114e8009c3a259"},
+    {file = "mypy-1.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7178def594014aa6c35a8ff411cf37d682f428b3b5617ca79029d8ae72f5402b"},
+    {file = "mypy-1.8.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ab3c84fa13c04aeeeabb2a7f67a25ef5d77ac9d6486ff33ded762ef353aa5592"},
+    {file = "mypy-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:99b00bc72855812a60d253420d8a2eae839b0afa4938f09f4d2aa9bb4654263a"},
+    {file = "mypy-1.8.0-py3-none-any.whl", hash = "sha256:538fd81bb5e430cc1381a443971c0475582ff9f434c16cd46d2c66763ce85d9d"},
+    {file = "mypy-1.8.0.tar.gz", hash = "sha256:6ff8b244d7085a0b425b56d327b480c3b29cafbd2eff27316a004f9a7391ae07"},
 ]
 
 [package.dependencies]
@@ -788,14 +788,40 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "ruff"
+version = "0.1.9"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.1.9-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:e6a212f436122ac73df851f0cf006e0c6612fe6f9c864ed17ebefce0eff6a5fd"},
+    {file = "ruff-0.1.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:28d920e319783d5303333630dae46ecc80b7ba294aeffedf946a02ac0b7cc3db"},
+    {file = "ruff-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:104aa9b5e12cb755d9dce698ab1b97726b83012487af415a4512fedd38b1459e"},
+    {file = "ruff-0.1.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1e63bf5a4a91971082a4768a0aba9383c12392d0d6f1e2be2248c1f9054a20da"},
+    {file = "ruff-0.1.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4d0738917c203246f3e275b37006faa3aa96c828b284ebfe3e99a8cb413c8c4b"},
+    {file = "ruff-0.1.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:69dac82d63a50df2ab0906d97a01549f814b16bc806deeac4f064ff95c47ddf5"},
+    {file = "ruff-0.1.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2aec598fb65084e41a9c5d4b95726173768a62055aafb07b4eff976bac72a592"},
+    {file = "ruff-0.1.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:744dfe4b35470fa3820d5fe45758aace6269c578f7ddc43d447868cfe5078bcb"},
+    {file = "ruff-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:479ca4250cab30f9218b2e563adc362bd6ae6343df7c7b5a7865300a5156d5a6"},
+    {file = "ruff-0.1.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:aa8344310f1ae79af9ccd6e4b32749e93cddc078f9b5ccd0e45bd76a6d2e8bb6"},
+    {file = "ruff-0.1.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:837c739729394df98f342319f5136f33c65286b28b6b70a87c28f59354ec939b"},
+    {file = "ruff-0.1.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e6837202c2859b9f22e43cb01992373c2dbfeae5c0c91ad691a4a2e725392464"},
+    {file = "ruff-0.1.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:331aae2cd4a0554667ac683243b151c74bd60e78fb08c3c2a4ac05ee1e606a39"},
+    {file = "ruff-0.1.9-py3-none-win32.whl", hash = "sha256:8151425a60878e66f23ad47da39265fc2fad42aed06fb0a01130e967a7a064f4"},
+    {file = "ruff-0.1.9-py3-none-win_amd64.whl", hash = "sha256:c497d769164df522fdaf54c6eba93f397342fe4ca2123a2e014a5b8fc7df81c7"},
+    {file = "ruff-0.1.9-py3-none-win_arm64.whl", hash = "sha256:0e17f53bcbb4fff8292dfd84cf72d767b5e146f009cccd40c2fad27641f8a7a9"},
+    {file = "ruff-0.1.9.tar.gz", hash = "sha256:b041dee2734719ddbb4518f762c982f2e912e7f28b8ee4fe1dee0b15d1b6e800"},
+]
+
+[[package]]
 name = "setuptools"
-version = "69.0.2"
+version = "69.0.3"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-69.0.2-py3-none-any.whl", hash = "sha256:1e8fdff6797d3865f37397be788a4e3cba233608e9b509382a2777d25ebde7f2"},
-    {file = "setuptools-69.0.2.tar.gz", hash = "sha256:735896e78a4742605974de002ac60562d286fa8051a7e2299445e8e8fbb01aa6"},
+    {file = "setuptools-69.0.3-py3-none-any.whl", hash = "sha256:385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05"},
+    {file = "setuptools-69.0.3.tar.gz", hash = "sha256:be1af57fc409f93647f2e8e4573a142ed38724b8cdd389706a867bb4efcf1e78"},
 ]
 
 [package.extras]
@@ -1156,4 +1182,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "e89a873e654ad8d69af1d05b0b719750014e4961b98b7f1e8631be3dc575e6b0"
+content-hash = "18ce93e5e811367b1d3300739c0b535d4f18e2066215770a33fe1b50d970fc65"

--- a/poetry.lock
+++ b/poetry.lock
@@ -662,6 +662,23 @@ files = [
 pytest = ">=3.2.5"
 
 [[package]]
+name = "pytest-order"
+version = "1.2.0"
+description = "pytest plugin to run your tests in a specific order"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pytest-order-1.2.0.tar.gz", hash = "sha256:944f86b6d441aa7b1da80f801c6ab65b84bbeba472d0a7a12eb43ba26650101a"},
+    {file = "pytest_order-1.2.0-py3-none-any.whl", hash = "sha256:9d65c3b6dc6d6ee984d6ae2c6c4aa4f1331e5b915116219075c888c8bcbb93b8"},
+]
+
+[package.dependencies]
+pytest = [
+    {version = ">=5.0", markers = "python_version < \"3.10\""},
+    {version = ">=6.2.4", markers = "python_version >= \"3.10\""},
+]
+
+[[package]]
 name = "pytest-rerunfailures"
 version = "11.1.2"
 description = "pytest plugin to re-run tests to eliminate flaky failures"
@@ -1182,4 +1199,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "18ce93e5e811367b1d3300739c0b535d4f18e2066215770a33fe1b50d970fc65"
+content-hash = "47f0c4c4488fe0a6aee0d7252d0947d7fc766a37950c783cd2c8950fed04fbf7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,9 @@ importlib-metadata = ">=4.2"
 autopep8 = "^1.7"
 flake8 = "^5.0.4"
 flake8-quotes = "^3.3"
+ruff = "^0.1.9"
 pytest = "^7.2.2"
+pytest-order = "^1.2.0"
 pytest-lazy-fixture = "^0.6.3"
 pytest-rerunfailures = "^11.1.2"
 mypy = "^1.1.1"
@@ -51,10 +53,29 @@ poethepoet = "^0.24.1"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.ruff]
+
+[tool.ruff.lint]
+select = ["D"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.pytest.ini_options]
+markers = [
+    "ci_exempt: mark a test as exempt from CI.",
+    "flaky_test: mark a test as potentially flaky.",
+  ]
+addopts = [
+    "--ignore=tests/api/v2/test_policies.py",
+    "--ignore=tests/api/v2/test_queries.py",
+  ]
+
 [tool.poe.tasks]
-test        = "pytest -m 'not ci_exempt and not flaky_test' tests/api/v2"
+test        = "pytest -v --order-scope=class -m 'not ci_exempt and not flaky_test' tests/api/v2"
 flaky_test  = "pytest -m 'flaky_test' tests"
 lint        = "flake8 . --exclude 'jupyter' --count --select=E9,F63,F7,F82 --show-source --statistics"
+lint-docstrings = "ruff check laceworksdk/"
 docs-clean.shell  = "rm -r docs-source/auto; rm -r docs/*"
 docs-build.shell  = "sphinx-apidoc -e -f -d 5 -o docs-source/auto laceworksdk && sphinx-build -M html docs-source docs"
 docs        = ["docs-clean", "docs-build"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,0 @@
-[pytest]
-markers =
-    ci_exempt: mark a test as exempt from CI.
-    flaky_test: mark a test as potentially flaky.
-
-addopts =
-    --ignore=tests/api/v2/test_policies.py
-    --ignore=tests/api/v2/test_queries.py

--- a/tests/api/test_crud_endpoint.py
+++ b/tests/api/test_crud_endpoint.py
@@ -4,6 +4,7 @@ Test suite for the community-developed Python SDK for interacting with Lacework 
 """
 
 from tests.api.test_base_endpoint import BaseEndpoint
+import pytest
 
 
 class CrudEndpoint(BaseEndpoint):
@@ -60,6 +61,8 @@ class CrudEndpoint(BaseEndpoint):
 
             self._check_object_values(api_object_update_body, response)
 
+    # if you don't run delete last you can run into some race conditions with the API
+    @pytest.mark.order("last")
     def test_api_delete(self, api_object, request):
         guid = request.config.cache.get(self.OBJECT_ID_NAME, None)
         assert guid is not None

--- a/tests/api/v2/test_agent_access_tokens.py
+++ b/tests/api/v2/test_agent_access_tokens.py
@@ -33,6 +33,7 @@ class TestAgentAccessTokens(CrudEndpoint):
         Agent Access Tokens shouldn't be created with tests
         """
 
+    @pytest.mark.order("first")
     def test_api_get_by_id(self, api_object):
         self._get_object_classifier_test(api_object, "id", self.OBJECT_ID_NAME)
 

--- a/tests/api/v2/test_agent_info.py
+++ b/tests/api/v2/test_agent_info.py
@@ -18,6 +18,6 @@ def api_object(api):
     return api.agent_info
 
 
-class TestConfigsEndpoint(SearchEndpoint):
+class TestAgentInfo(SearchEndpoint):
 
     OBJECT_TYPE = AgentInfoAPI

--- a/tests/api/v2/test_alert_channels.py
+++ b/tests/api/v2/test_alert_channels.py
@@ -48,10 +48,11 @@ class TestAlertChannels(CrudEndpoint):
     OBJECT_ID_NAME = "intgGuid"
     OBJECT_TYPE = AlertChannelsAPI
 
-    @pytest.mark.flaky_test
+    @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)
 
+    @pytest.mark.order("second")
     def test_api_get_by_type(self, api_object):
         self._get_object_classifier_test(api_object, "type")
 
@@ -79,10 +80,10 @@ class TestAlertChannels(CrudEndpoint):
 @pytest.mark.parametrize("api_object", [pytest.lazy_fixture("api_object_org")])
 class TestAlertChannelsOrg(TestAlertChannels):
 
-    @pytest.mark.flaky_test
+    @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)
 
-    @pytest.mark.flaky_test
+    @pytest.mark.order("second")
     def test_api_get_by_type(self, api_object):
         self._get_object_classifier_test(api_object, "type")

--- a/tests/api/v2/test_alert_profiles.py
+++ b/tests/api/v2/test_alert_profiles.py
@@ -58,5 +58,6 @@ class TestAlertProfiles(CrudEndpoint):
         """
         pass
 
+    @pytest.mark.order("first")
     def test_api_get_by_id(self, api_object):
         self._get_object_classifier_test(api_object, "id", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_alert_rules.py
+++ b/tests/api/v2/test_alert_rules.py
@@ -45,6 +45,7 @@ class TestAlertRules(CrudEndpoint):
     OBJECT_ID_NAME = "mcGuid"
     OBJECT_TYPE = AlertRulesAPI
 
+    @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)
 

--- a/tests/api/v2/test_cloud_accounts.py
+++ b/tests/api/v2/test_cloud_accounts.py
@@ -46,8 +46,10 @@ class TestCloudAccounts(ReadEndpoint):
     OBJECT_ID_NAME = "intgGuid"
     OBJECT_TYPE = CloudAccountsAPI
 
+    @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)
 
+    @pytest.mark.order("second")
     def test_api_get_by_type(self, api_object):
         self._get_object_classifier_test(api_object, "type")

--- a/tests/api/v2/test_container_registries.py
+++ b/tests/api/v2/test_container_registries.py
@@ -41,8 +41,10 @@ class TestContainerRegistries(CrudEndpoint):
     OBJECT_ID_NAME = "intgGuid"
     OBJECT_TYPE = ContainerRegistriesAPI
 
+    @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)
 
+    @pytest.mark.order("second")
     def test_api_get_by_type(self, api_object):
         self._get_object_classifier_test(api_object, "type")

--- a/tests/api/v2/test_data_export_rules.py
+++ b/tests/api/v2/test_data_export_rules.py
@@ -44,5 +44,6 @@ class TestDataExportRules(CrudEndpoint):
     OBJECT_ID_NAME = "mcGuid"
     OBJECT_TYPE = DataExportRulesAPI
 
+    @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_datasources.py
+++ b/tests/api/v2/test_datasources.py
@@ -25,5 +25,6 @@ class TestDatasources(BaseEndpoint):
         response = api_object.get()
         assert "data" in response.keys()
 
+    @pytest.mark.order("first")
     def test_api_get_by_type(self, api_object):
         self._get_object_classifier_test(api_object, "type", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_events.py
+++ b/tests/api/v2/test_events.py
@@ -17,6 +17,6 @@ def api_object(api):
 
 
 @pytest.mark.flaky_test
-class TestEvidenceEndpoint(SearchEndpoint):
+class TestEventsEndpoint(SearchEndpoint):
 
     OBJECT_TYPE = EventsAPI

--- a/tests/api/v2/test_inventory.py
+++ b/tests/api/v2/test_inventory.py
@@ -18,7 +18,7 @@ def api_object(api):
     return api.inventory
 
 
-class TestConfigsEndpoint(SearchEndpoint):
+class TestInventory(SearchEndpoint):
 
     OBJECT_TYPE = InventoryAPI
 

--- a/tests/api/v2/test_organization_info.py
+++ b/tests/api/v2/test_organization_info.py
@@ -16,7 +16,7 @@ def api_object(api):
     return api.organization_info
 
 
-class TestDatasources(BaseEndpoint):
+class TestOrganizationInfo(BaseEndpoint):
 
     OBJECT_ID_NAME = "name"
     OBJECT_TYPE = OrganizationInfoAPI

--- a/tests/api/v2/test_policy_exceptions.py
+++ b/tests/api/v2/test_policy_exceptions.py
@@ -69,6 +69,8 @@ class TestPolicyExceptions(CrudEndpoint):
 
         request.config.cache.set(self.OBJECT_ID_NAME, response["data"][self.OBJECT_ID_NAME])
 
+    @pytest.mark.flaky_test
+    @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object, policy_id, request):
         guid = request.config.cache.get(self.OBJECT_ID_NAME, None)
         assert guid is not None

--- a/tests/api/v2/test_queries.py
+++ b/tests/api/v2/test_queries.py
@@ -54,6 +54,7 @@ class TestQueries(CrudEndpoint):
     OBJECT_ID_NAME = "queryId"
     OBJECT_TYPE = QueriesAPI
 
+    @pytest.mark.order("first")
     def test_api_get_by_id(self, api_object):
         self._get_object_classifier_test(api_object, "id", self.OBJECT_ID_NAME)
 

--- a/tests/api/v2/test_report_definitions.py
+++ b/tests/api/v2/test_report_definitions.py
@@ -93,7 +93,7 @@ def api_object_update_body(random_text):
 
 
 @pytest.mark.flaky_test
-class TestAlertProfiles(CrudEndpoint):
+class TestReportDefinitions(CrudEndpoint):
 
     OBJECT_ID_NAME = "reportDefinitionGuid"
     OBJECT_TYPE = ReportDefinitionsAPI
@@ -105,5 +105,6 @@ class TestAlertProfiles(CrudEndpoint):
         """
         pass
 
+    @pytest.mark.order("first")
     def test_api_get_by_id(self, api_object):
         self._get_object_classifier_test(api_object, "id", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_report_rules.py
+++ b/tests/api/v2/test_report_rules.py
@@ -45,10 +45,12 @@ def api_object_update_body(random_text):
     }
 
 
-class TestAlertRules(CrudEndpoint):
+class TestReportRules(CrudEndpoint):
 
     OBJECT_ID_NAME = "mcGuid"
     OBJECT_TYPE = ReportRulesAPI
 
+    @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)
+

--- a/tests/api/v2/test_resource_groups.py
+++ b/tests/api/v2/test_resource_groups.py
@@ -40,13 +40,13 @@ def api_object_update_body(random_text):
         }
     }
 
-
+@pytest.mark.flaky_test
 class TestResourceGroups(CrudEndpoint):
 
     OBJECT_ID_NAME = "resourceGuid"
     OBJECT_TYPE = ResourceGroupsAPI
     OBJECT_PARAM_EXCEPTIONS = ["props"]
 
-    @pytest.mark.flaky_test
+    @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_team_members.py
+++ b/tests/api/v2/test_team_members.py
@@ -37,11 +37,11 @@ def api_object_update_body():
     }
 
 
-@pytest.mark.flaky_test
 class TestTeamMembers(CrudEndpoint):
 
     OBJECT_ID_NAME = "userGuid"
     OBJECT_TYPE = TeamMembersAPI
 
+    @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_team_users.py
+++ b/tests/api/v2/test_team_users.py
@@ -41,5 +41,6 @@ class TestTeamUsers(CrudEndpoint):
         "Not implemented"
         pass
 
+    @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_user_groups.py
+++ b/tests/api/v2/test_user_groups.py
@@ -26,7 +26,7 @@ def test_user(api, random_text):
     api.team_users.delete(guid)
 
 
-class TestUserProfile(BaseEndpoint):
+class TestUserGroups(BaseEndpoint):
 
     OBJECT_TYPE = UserGroupsAPI
 

--- a/tests/api/v2/test_vulnerability_exceptions.py
+++ b/tests/api/v2/test_vulnerability_exceptions.py
@@ -50,5 +50,6 @@ class TestVulnerabilityExceptions(CrudEndpoint):
     OBJECT_ID_NAME = "exceptionGuid"
     OBJECT_TYPE = VulnerabilityExceptionsAPI
 
+    @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_vulnerability_policies.py
+++ b/tests/api/v2/test_vulnerability_policies.py
@@ -53,5 +53,6 @@ class TestVulnerabilityExceptions(CrudEndpoint):
     OBJECT_ID_NAME = "policyGuid"
     OBJECT_TYPE = VulnerabilityPoliciesAPI
 
+    @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)


### PR DESCRIPTION
Summary:

Seeing random failures due to race condition in which "get_by_guid" test would still return deleted object after delete call, causing subsequent "get details" call to fail with 404. 

Details:

Add pytest-order and ensure that delete test always runs last for any given endpoint
Disable slack alerting until tests are working for sure.

Issue:

https://lacework.atlassian.net/browse/GROW-2297

