### PR TITLE
refactor: Make base classmethods private

### DIFF
--- a/docs-source/conf.py
+++ b/docs-source/conf.py
@@ -5,13 +5,15 @@
 
 import os
 import sys
+
+
 #sys.path.insert(0, os.path.abspath('../laceworksdk'))
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'Lacework Python SDK'
-copyright = '2023, Lacework'
+copyright = '2024, Lacework'
 author = 'Jon Stewart, Tim MacDonald'
 
 # -- General configuration ---------------------------------------------------

--- a/laceworksdk/api/base_endpoint.py
+++ b/laceworksdk/api/base_endpoint.py
@@ -20,7 +20,7 @@ class BaseEndpoint:
         self._object_type = object_type
         self._endpoint_root = endpoint_root
 
-    def build_dict_from_items(self, *dicts, **items):
+    def _build_dict_from_items(self, *dicts, **items):
         """A method to build a dictionary based on inputs, pruning items that are None.
 
         Args:
@@ -43,7 +43,7 @@ class BaseEndpoint:
 
         return result
 
-    def build_url(self, id=None, resource=None, action=None):
+    def _build_url(self, id=None, resource=None, action=None):
         """Builds the URL to use based on the endpoint path, resource, type, and ID.
 
         Args:
@@ -147,7 +147,7 @@ class BaseEndpoint:
         """Get the :class:`HttpSession` instance the object is using."""
         return self._session
 
-    def validate_json(self, json, subtype=None):
+    def _validate_json(self, json, subtype=None):
         """TODO: A method to validate the provided JSON based on the schema of the current object."""
         schema = self._get_schema(subtype)
 

--- a/laceworksdk/api/crud_endpoint.py
+++ b/laceworksdk/api/crud_endpoint.py
@@ -28,9 +28,9 @@ class CrudEndpoint(BaseEndpoint):
             dict: JSON containing the new object info
 
         """
-        json = self.build_dict_from_items(request_params)
+        json = self._build_dict_from_items(request_params)
 
-        response = self._session.post(self.build_url(), json=json, params=params)
+        response = self._session.post(self._build_url(), json=json, params=params)
 
         return response.json()
 
@@ -45,10 +45,10 @@ class CrudEndpoint(BaseEndpoint):
         Returns:
             dict: JSON containing the retrieved object(s)
         """
-        params = self.build_dict_from_items(request_params)
+        params = self._build_dict_from_items(request_params)
 
         response = self._session.get(
-            self.build_url(id=id, resource=resource), params=params
+            self._build_url(id=id, resource=resource), params=params
         )
 
         return response.json()
@@ -77,7 +77,7 @@ class CrudEndpoint(BaseEndpoint):
         Yields:
             dict: returns a generator which yields a page of objects at a time as returned by the Lacework API.
         """
-        response = self._session.post(self.build_url(action="search"), json=json)
+        response = self._session.post(self._build_url(action="search"), json=json)
 
         return response.json()
 
@@ -93,9 +93,9 @@ class CrudEndpoint(BaseEndpoint):
             dict: JSON containing the updated object info
 
         """
-        json = self.build_dict_from_items(request_params)
+        json = self._build_dict_from_items(request_params)
 
-        response = self._session.patch(self.build_url(id=id), json=json, params=params)
+        response = self._session.patch(self._build_url(id=id), json=json, params=params)
 
         return response.json()
 
@@ -109,7 +109,7 @@ class CrudEndpoint(BaseEndpoint):
         Returns:
             requests.models.Response: a Requests response object containing the response code
         """
-        response = self._session.delete(self.build_url(id=id), params=params)
+        response = self._session.delete(self._build_url(id=id), params=params)
 
         return response
 

--- a/laceworksdk/api/read_endpoint.py
+++ b/laceworksdk/api/read_endpoint.py
@@ -35,10 +35,10 @@ class ReadEndpoint(BaseEndpoint):
         if not resource and self.RESOURCE:
             resource = self.RESOURCE
 
-        params = self.build_dict_from_items(request_params)
+        params = self._build_dict_from_items(request_params)
 
         response = self._session.get(
-            self.build_url(id=id, resource=resource), params=params
+            self._build_url(id=id, resource=resource), params=params
         )
 
         return response.json()

--- a/laceworksdk/api/search_endpoint.py
+++ b/laceworksdk/api/search_endpoint.py
@@ -49,7 +49,7 @@ class SearchEndpoint(BaseEndpoint):
             resource = self.RESOURCE
 
         response = self._session.post(
-            self.build_url(resource=resource, action="search"), json=json
+            self._build_url(resource=resource, action="search"), json=json
         )
 
         while True:

--- a/laceworksdk/api/v2/alert_channels.py
+++ b/laceworksdk/api/v2/alert_channels.py
@@ -121,6 +121,6 @@ class AlertChannelsAPI(CrudEndpoint):
         Returns:
             requests.models.Response: a Requests response object containing the response code
         """
-        response = self._session.post(self.build_url(resource=guid, action="test"))
+        response = self._session.post(self._build_url(resource=guid, action="test"))
 
         return response

--- a/laceworksdk/api/v2/alerts.py
+++ b/laceworksdk/api/v2/alerts.py
@@ -35,11 +35,11 @@ class AlertsAPI(SearchEndpoint):
           dict: The requested alert(s)
 
         """
-        params = self.build_dict_from_items(
+        params = self._build_dict_from_items(
             request_params, start_time=start_time, end_time=end_time
         )
 
-        response = self._session.get(self.build_url(), params=params)
+        response = self._session.get(self._build_url(), params=params)
 
         return_data = {"data": []}
         current_rows = 0
@@ -84,9 +84,9 @@ class AlertsAPI(SearchEndpoint):
         Returns:
             dict: The requested alert details.
         """
-        params = self.build_dict_from_items(request_params, scope=scope)
+        params = self._build_dict_from_items(request_params, scope=scope)
 
-        response = self._session.get(self.build_url(id=id), params=params)
+        response = self._session.get(self._build_url(id=id), params=params)
 
         return response.json()
 
@@ -101,10 +101,10 @@ class AlertsAPI(SearchEndpoint):
             dict: The posted comment
 
         """
-        json = self.build_dict_from_items(comment=comment)
+        json = self._build_dict_from_items(comment=comment)
 
         response = self._session.post(
-            self.build_url(resource=id, action="comment"), json=json
+            self._build_url(resource=id, action="comment"), json=json
         )
 
         return response.json()
@@ -120,10 +120,10 @@ class AlertsAPI(SearchEndpoint):
         Returns:
             requests.models.Response: a Requests response object containing the response code
         """
-        json = self.build_dict_from_items(reason=reason, comment=comment)
+        json = self._build_dict_from_items(reason=reason, comment=comment)
 
         response = self._session.post(
-            self.build_url(resource=id, action="close"), json=json
+            self._build_url(resource=id, action="close"), json=json
         )
 
         return response.json()

--- a/laceworksdk/api/v2/audit_logs.py
+++ b/laceworksdk/api/v2/audit_logs.py
@@ -32,11 +32,11 @@ class AuditLogsAPI(BaseEndpoint):
         Returns:
             dict: The audit logs for the requested time period.
         """
-        params = self.build_dict_from_items(
+        params = self._build_dict_from_items(
             request_params, start_time=start_time, end_time=end_time
         )
 
-        response = self._session.get(self.build_url(), params=params)
+        response = self._session.get(self._build_url(), params=params)
 
         return response.json()
 
@@ -63,5 +63,5 @@ class AuditLogsAPI(BaseEndpoint):
             dict: returns a generator which yields a page of objects at a time as returned by the Lacework API.
         """
 
-        response = self._session.post(self.build_url(action="search"), json=json)
+        response = self._session.post(self._build_url(action="search"), json=json)
         return response.json()

--- a/laceworksdk/api/v2/cloud_activities.py
+++ b/laceworksdk/api/v2/cloud_activities.py
@@ -34,11 +34,11 @@ class CloudActivitiesAPI(BaseEndpoint):
             dict: The requested cloud activity data.
 
         """
-        params = self.build_dict_from_items(
+        params = self._build_dict_from_items(
             request_params, start_time=start_time, end_time=end_time
         )
 
-        response = self._session.get(self.build_url(), params=params)
+        response = self._session.get(self._build_url(), params=params)
 
         return response.json()
 
@@ -57,11 +57,11 @@ class CloudActivitiesAPI(BaseEndpoint):
         Yields:
             dict: a generator which yields a dict of cloud activities.
         """
-        params = self.build_dict_from_items(
+        params = self._build_dict_from_items(
             request_params, start_time=start_time, end_time=end_time
         )
 
-        for page in self._session.get_pages(self.build_url(), params=params):
+        for page in self._session.get_pages(self._build_url(), params=params):
             yield page.json()
 
     def get_data_items(self, start_time=None, end_time=None, **request_params):
@@ -79,13 +79,13 @@ class CloudActivitiesAPI(BaseEndpoint):
         Yields:
             dict: a generator which yields multipe dicts of cloud activities.
         """
-        params = self.build_dict_from_items(
+        params = self._build_dict_from_items(
             request_params,
             start_time=start_time,
             end_time=end_time,
         )
 
-        for item in self._session.get_data_items(self.build_url(), params=params):
+        for item in self._session.get_data_items(self._build_url(), params=params):
             yield item
 
     def search(self, json=None):
@@ -106,5 +106,5 @@ class CloudActivitiesAPI(BaseEndpoint):
              dict: returns a generator which yields a page of objects at a time as returned by the Lacework API.
         """
 
-        response = self._session.post(self.build_url(action="search"), json=json)
+        response = self._session.post(self._build_url(action="search"), json=json)
         return response.json()

--- a/laceworksdk/api/v2/contract_info.py
+++ b/laceworksdk/api/v2/contract_info.py
@@ -30,8 +30,8 @@ class ContractInfoAPI(BaseEndpoint):
             request_params (dict, optional): Use to pass any additional parameters the API
 
         """
-        params = self.build_dict_from_items(request_params)
+        params = self._build_dict_from_items(request_params)
 
-        response = self._session.get(self.build_url(), params=params)
+        response = self._session.get(self._build_url(), params=params)
 
         return response.json()

--- a/laceworksdk/api/v2/datasources.py
+++ b/laceworksdk/api/v2/datasources.py
@@ -29,7 +29,7 @@ class DatasourcesAPI(BaseEndpoint):
         Returns:
             dict: All datasources
         """
-        response = self._session.get(self.build_url())
+        response = self._session.get(self._build_url())
         return response.json()
 
     def get_datasource(self, datasource):
@@ -41,7 +41,7 @@ class DatasourcesAPI(BaseEndpoint):
         Returns:
             dict: The datasource schema.
         """
-        return self._session.get(self.build_url(resource=datasource)).json()
+        return self._session.get(self._build_url(resource=datasource)).json()
 
     def list_data_sources(self):
         """A method to list the datasources that are available.

--- a/laceworksdk/api/v2/inventory.py
+++ b/laceworksdk/api/v2/inventory.py
@@ -32,9 +32,9 @@ class InventoryAPI(SearchEndpoint):
             dict: Status of scan
 
         """
-        params = self.build_dict_from_items(csp=csp)
+        params = self._build_dict_from_items(csp=csp)
 
-        response = self._session.post(self.build_url(action="scan"), params=params)
+        response = self._session.post(self._build_url(action="scan"), params=params)
 
         return response.json()
 
@@ -48,8 +48,8 @@ class InventoryAPI(SearchEndpoint):
             dict: Status of scan
 
         """
-        params = self.build_dict_from_items(csp=csp)
+        params = self._build_dict_from_items(csp=csp)
 
-        response = self._session.get(self.build_url(action="scan"), params=params)
+        response = self._session.get(self._build_url(action="scan"), params=params)
 
         return response.json()

--- a/laceworksdk/api/v2/organization_info.py
+++ b/laceworksdk/api/v2/organization_info.py
@@ -29,6 +29,6 @@ class OrganizationInfoAPI(BaseEndpoint):
             dict: Organization info
 
         """
-        response = self._session.get(self.build_url())
+        response = self._session.get(self._build_url())
 
         return response.json()

--- a/laceworksdk/api/v2/policies.py
+++ b/laceworksdk/api/v2/policies.py
@@ -179,7 +179,7 @@ class PoliciesAPI(CrudEndpoint):
           dict: The updated policies.
 
         """
-        response = self._session.patch(self.build_url(), json=json)
+        response = self._session.patch(self._build_url(), json=json)
 
         return response.json()
 

--- a/laceworksdk/api/v2/policy_exceptions.py
+++ b/laceworksdk/api/v2/policy_exceptions.py
@@ -39,7 +39,7 @@ class PolicyExceptionsAPI(CrudEndpoint):
             dict: The created policy exception
 
         """
-        params = self.build_dict_from_items(policy_id=policy_id)
+        params = self._build_dict_from_items(policy_id=policy_id)
 
         return super().create(
             params=params,
@@ -99,7 +99,7 @@ class PolicyExceptionsAPI(CrudEndpoint):
             dict: The updated policy exception
 
         """
-        params = self.build_dict_from_items(policy_id=policy_id)
+        params = self._build_dict_from_items(policy_id=policy_id)
 
         return super().update(
             id=exception_id,
@@ -119,6 +119,6 @@ class PolicyExceptionsAPI(CrudEndpoint):
         Returns:
             requests.models.Response: a Requests response object containing the response code
         """
-        params = self.build_dict_from_items(policy_id=policy_id)
+        params = self._build_dict_from_items(policy_id=policy_id)
 
         return super().delete(id=exception_id, params=params)

--- a/laceworksdk/api/v2/queries.py
+++ b/laceworksdk/api/v2/queries.py
@@ -93,7 +93,7 @@ class QueriesAPI(CrudEndpoint):
         for key, value in arguments.items():
             json["arguments"].append({"name": key, "value": value})
 
-        response = self._session.post(self.build_url(action="execute"), json=json)
+        response = self._session.post(self._build_url(action="execute"), json=json)
 
         return response.json()
 
@@ -113,7 +113,7 @@ class QueriesAPI(CrudEndpoint):
             json["arguments"].append({"name": key, "value": value})
 
         response = self._session.post(
-            self.build_url(resource=query_id, action="execute"), json=json
+            self._build_url(resource=query_id, action="execute"), json=json
         )
 
         return response.json()
@@ -129,11 +129,11 @@ class QueriesAPI(CrudEndpoint):
         Returns:
             dict: Validation Results
         """
-        json = self.build_dict_from_items(
+        json = self._build_dict_from_items(
             request_params, query_text=query_text, evaluator_id=evaluator_id
         )
 
-        response = self._session.post(self.build_url(action="validate"), json=json)
+        response = self._session.post(self._build_url(action="validate"), json=json)
 
         return response.json()
 

--- a/laceworksdk/api/v2/report_definitions.py
+++ b/laceworksdk/api/v2/report_definitions.py
@@ -112,13 +112,13 @@ class ReportDefinitionsAPI(CrudEndpoint):
         Returns:
             dict: The updated report definition
         """
-        json = self.build_dict_from_items(
+        json = self._build_dict_from_items(
             report_name=report_name,
             report_definition=report_definition,
             **request_params,
         )
 
-        response = self._session.patch(self.build_url(id=id), json=json)
+        response = self._session.patch(self._build_url(id=id), json=json)
 
         return response.json()
 

--- a/laceworksdk/api/v2/reports.py
+++ b/laceworksdk/api/v2/reports.py
@@ -44,7 +44,7 @@ class ReportsAPI(BaseEndpoint):
             dict: The details of the report
         """
 
-        params = self.build_dict_from_items(
+        params = self._build_dict_from_items(
             primary_query_id=primary_query_id,
             secondary_query_id=secondary_query_id,
             format=format,
@@ -52,7 +52,7 @@ class ReportsAPI(BaseEndpoint):
             **request_params,
         )
 
-        response = self._session.get(self.build_url(), params=params)
+        response = self._session.get(self._build_url(), params=params)
 
         if format == "json":
             return response.json()

--- a/laceworksdk/api/v2/schemas.py
+++ b/laceworksdk/api/v2/schemas.py
@@ -36,7 +36,7 @@ class SchemasAPI(BaseEndpoint):
             dict: The requested schema
 
         """
-        response = self._session.get(self.build_url(id=subtype, resource=type))
+        response = self._session.get(self._build_url(id=subtype, resource=type))
 
         return response.json()
 

--- a/laceworksdk/api/v2/user_groups.py
+++ b/laceworksdk/api/v2/user_groups.py
@@ -22,12 +22,12 @@ class UserGroupsAPI(BaseEndpoint):
         super().__init__(session, "UserGroups")
 
     def __modify_members(self, guid, user_guids, action):
-        json = self.build_dict_from_items(
+        json = self._build_dict_from_items(
             user_guids=user_guids,
         )
 
         response = self._session.post(
-            self.build_url(resource=guid, action=action), json=json, params=None
+            self._build_url(resource=guid, action=action), json=json, params=None
         )
 
         return response.json()

--- a/laceworksdk/api/v2/user_profile.py
+++ b/laceworksdk/api/v2/user_profile.py
@@ -33,6 +33,6 @@ class UserProfileAPI(BaseEndpoint):
             dict: Details of the requested sub-account(s)
 
         """
-        response = self._session.get(self.build_url(), params=account_name)
+        response = self._session.get(self._build_url(), params=account_name)
 
         return response.json()

--- a/laceworksdk/api/v2/vulnerabilities.py
+++ b/laceworksdk/api/v2/vulnerabilities.py
@@ -61,12 +61,12 @@ class VulnerabilitiesAPI:
                 dict: The status of the requested scan
             """
 
-            json = self.build_dict_from_items(
+            json = self._build_dict_from_items(
                 **request_params, registry=registry, repository=repository, tag=tag
             )
 
             response = self._session.post(
-                self.build_url(resource="Containers", action="scan"), json=json
+                self._build_url(resource="Containers", action="scan"), json=json
             )
 
             return response.json()
@@ -86,7 +86,7 @@ class VulnerabilitiesAPI:
                 )
 
             response = self._session.get(
-                self.build_url(id=request_id, resource="Containers", action="scan")
+                self._build_url(id=request_id, resource="Containers", action="scan")
             )
 
             return response.json()
@@ -118,12 +118,12 @@ class VulnerabilitiesAPI:
 
             """
 
-            json = self.build_dict_from_items(
+            json = self._build_dict_from_items(
                 **request_params, os_pkg_info_list=os_pkg_info_list
             )
 
             response = self._session.post(
-                self.build_url(resource="SoftwarePackages", action="scan"), json=json
+                self._build_url(resource="SoftwarePackages", action="scan"), json=json
             )
 
             return response.json()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "laceworksdk"
-version = "2.1.0"
+version = "3.0.0"
 description = "Community-developed Python SDK for the Lacework APIs"
 authors = ["Jon Stewart <jon.stewart@lacework.net>"]
 maintainers = ["Jon Stewart <jon.stewart@lacework.net>", "Matthew Cadorette <matthew.cadorette@lacework.net>"]


### PR DESCRIPTION
These should have been private. This change fixes this which is required for the auto api doc generator to keep these methods out of the API docs.


Testing:

Ran tests locally, all passed

Issue:

https://lacework.atlassian.net/browse/GROW-2671