### PR TITLE
test: fix testAlerts failures

### DIFF
--- a/tests/api/v2/test_alerts.py
+++ b/tests/api/v2/test_alerts.py
@@ -38,7 +38,7 @@ class TestAlerts(ReadEndpoint):
         "Events",
         "RelatedAlerts",
         "Integrations",
-        "Timeline"
+        # "Timeline"  <-- Commented because most alertIds don't support this scope, causing test to fail
     ]
 
     def test_get_by_date(self, api_object):


### PR DESCRIPTION
removed "timeline" scope from Alerts test because get_by_guid test failing due to most alert guids not supporting timeline scope

issue: 

https://lacework.atlassian.net/browse/GROW-2664
