### PR TITLE
ci: add poetry to release action

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -25,6 +25,10 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install poetry
+      run: |
+        pipx install poetry
+
     - name: Python Semantic Major Release
       if: ${{ inputs.bump_major == 'true' }}
       uses: python-semantic-release/python-semantic-release@master


### PR DESCRIPTION
Poetry needs to be installed as part of the github action for semantic release

Issue: 

https://lacework.atlassian.net/browse/GROW-2746