### PR TITLE
ci(release): add version command to release action

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -64,6 +64,7 @@ jobs:
         git config --global user.signingkey ${{ secrets.GPG_SIGNING_KEY }}
         git config commit.gpgsign true
         git config --global tag.gpgSign true
+        poetry run semantic-release version
         poetry run semantic-release publish
       env:
         GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
version command was missing from the release workflow branch for minor releases.  