### PR TITLE
ci(release): remove commit of repo to main in GH release action

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -64,6 +64,7 @@ jobs:
         git config --global user.signingkey ${{ secrets.GPG_SIGNING_KEY }}
         git config commit.gpgsign true
         git config --global tag.gpgSign true
+        poetry run semantic-release version
         poetry run semantic-release publish
       env:
         GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -21,9 +21,10 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Install poetry
       run: |

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -51,7 +51,7 @@ jobs:
         git config --global user.signingkey ${{ secrets.GPG_SIGNING_KEY }}
         git config commit.gpgsign true
         git config --global tag.gpgSign true
-        poetry run semantic-release version --major
+        poetry run semantic-release version --major --no-commit
         poetry run semantic-release publish
       env:
         GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -65,7 +65,7 @@ jobs:
         git config --global user.signingkey ${{ secrets.GPG_SIGNING_KEY }}
         git config commit.gpgsign true
         git config --global tag.gpgSign true
-        poetry run semantic-release version
+        poetry run semantic-release version --no-commit
         poetry run semantic-release publish
       env:
         GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Start to move changelog generation out of release action and into push action to avoid bumping up against main branch protection