### PR TITLE
test: retry failing tests and enable slack notification

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -55,14 +55,14 @@ jobs:
           LW_API_KEY: ${{ secrets.LW_API_KEY }}
           LW_API_SECRET: ${{ secrets.LW_API_SECRET }}
           LW_BASE_DOMAIN: ${{ secrets.LW_BASE_DOMAIN }}
-#      - name: Report Status
-#        if: always()
-#        uses: ravsamhq/notify-slack-action@v2
-#        with:
-#          status: ${{ job.status }}
-#          notify_when: "failure"
-#          notification_title: "{workflow} has {status_message}"
-#          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
-#          footer: "Linked Repo <{repo_url}|{repo}> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Report Status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "{workflow} has {status_message}"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/tests/api/v2/test_agent_access_tokens.py
+++ b/tests/api/v2/test_agent_access_tokens.py
@@ -33,6 +33,7 @@ class TestAgentAccessTokens(CrudEndpoint):
         Agent Access Tokens shouldn't be created with tests
         """
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     @pytest.mark.order("first")
     def test_api_get_by_id(self, api_object):
         self._get_object_classifier_test(api_object, "id", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_alert_profiles.py
+++ b/tests/api/v2/test_alert_profiles.py
@@ -58,6 +58,7 @@ class TestAlertProfiles(CrudEndpoint):
         """
         pass
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     @pytest.mark.order("first")
     def test_api_get_by_id(self, api_object):
         self._get_object_classifier_test(api_object, "id", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_alert_rules.py
+++ b/tests/api/v2/test_alert_rules.py
@@ -45,6 +45,7 @@ class TestAlertRules(CrudEndpoint):
     OBJECT_ID_NAME = "mcGuid"
     OBJECT_TYPE = AlertRulesAPI
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_alerts.py
+++ b/tests/api/v2/test_alerts.py
@@ -70,12 +70,14 @@ class TestAlerts(ReadEndpoint):
         response = api_object.comment(guid, "Test Comment")
         assert "data" in response.keys()
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to close an  alert that isn't allowed
     def test_close_fp(self, api_object, open_alerts_filter):
         guid = self._search_random_object(api_object, self.OBJECT_ID_NAME, open_alerts_filter)
         if guid:
             response = api_object.close(guid, 1)
             assert "data" in response.keys()
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to close an  alert that isn't allowed
     def test_close_other(self, api_object, open_alerts_filter):
         guid = self._search_random_object(api_object, self.OBJECT_ID_NAME, open_alerts_filter)
         if guid:

--- a/tests/api/v2/test_container_registries.py
+++ b/tests/api/v2/test_container_registries.py
@@ -41,6 +41,7 @@ class TestContainerRegistries(CrudEndpoint):
     OBJECT_ID_NAME = "intgGuid"
     OBJECT_TYPE = ContainerRegistriesAPI
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_data_export_rules.py
+++ b/tests/api/v2/test_data_export_rules.py
@@ -44,6 +44,7 @@ class TestDataExportRules(CrudEndpoint):
     OBJECT_ID_NAME = "mcGuid"
     OBJECT_TYPE = DataExportRulesAPI
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_policies.py
+++ b/tests/api/v2/test_policies.py
@@ -68,6 +68,7 @@ class TestPolicies(CrudEndpoint):
     OBJECT_ID_NAME = "policyId"
     OBJECT_TYPE = PoliciesAPI
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     def test_api_get_by_id(self, api_object):
         self._get_object_classifier_test(api_object, "id", self.OBJECT_ID_NAME)
 

--- a/tests/api/v2/test_policy_exceptions.py
+++ b/tests/api/v2/test_policy_exceptions.py
@@ -75,6 +75,7 @@ class TestPolicyExceptions(CrudEndpoint):
 
         request.config.cache.set(self.OBJECT_ID_NAME, response["data"][self.OBJECT_ID_NAME])
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object, policy_id, policy_exception_id):
         response = api_object.get(policy_exception_id, policy_id)

--- a/tests/api/v2/test_queries.py
+++ b/tests/api/v2/test_queries.py
@@ -54,6 +54,7 @@ class TestQueries(CrudEndpoint):
     OBJECT_ID_NAME = "queryId"
     OBJECT_TYPE = QueriesAPI
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     @pytest.mark.order("first")
     def test_api_get_by_id(self, api_object):
         self._get_object_classifier_test(api_object, "id", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_report_definitions.py
+++ b/tests/api/v2/test_report_definitions.py
@@ -78,6 +78,7 @@ class TestReportDefinitions(CrudEndpoint):
         """
         pass
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     @pytest.mark.order("first")
     def test_api_get_by_id(self, api_object):
         self._get_object_classifier_test(api_object, "id", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_report_rules.py
+++ b/tests/api/v2/test_report_rules.py
@@ -50,7 +50,7 @@ class TestReportRules(CrudEndpoint):
     OBJECT_ID_NAME = "mcGuid"
     OBJECT_TYPE = ReportRulesAPI
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)
-

--- a/tests/api/v2/test_resource_groups.py
+++ b/tests/api/v2/test_resource_groups.py
@@ -46,6 +46,7 @@ class TestResourceGroups(CrudEndpoint):
     OBJECT_TYPE = ResourceGroupsAPI
     OBJECT_PARAM_EXCEPTIONS = ["props"]
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         response = api_object.get()

--- a/tests/api/v2/test_team_members.py
+++ b/tests/api/v2/test_team_members.py
@@ -42,6 +42,7 @@ class TestTeamMembers(CrudEndpoint):
     OBJECT_ID_NAME = "userGuid"
     OBJECT_TYPE = TeamMembersAPI
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_team_users.py
+++ b/tests/api/v2/test_team_users.py
@@ -41,6 +41,7 @@ class TestTeamUsers(CrudEndpoint):
         "Not implemented"
         pass
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_vulnerability_exceptions.py
+++ b/tests/api/v2/test_vulnerability_exceptions.py
@@ -50,6 +50,7 @@ class TestVulnerabilityExceptions(CrudEndpoint):
     OBJECT_ID_NAME = "exceptionGuid"
     OBJECT_TYPE = VulnerabilityExceptionsAPI
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)

--- a/tests/api/v2/test_vulnerability_policies.py
+++ b/tests/api/v2/test_vulnerability_policies.py
@@ -53,6 +53,7 @@ class TestVulnerabilityExceptions(CrudEndpoint):
     OBJECT_ID_NAME = "policyGuid"
     OBJECT_TYPE = VulnerabilityPoliciesAPI
 
+    @pytest.mark.flaky(reruns=10)   # Because sometimes this attempts to get an object that has just been deleted
     @pytest.mark.order("first")
     def test_api_get_by_guid(self, api_object):
         self._get_object_classifier_test(api_object, "guid", self.OBJECT_ID_NAME)


### PR DESCRIPTION
Some tests fail because:

- Objects are randomly selected and not all object types are suitable for all tests ( e.g. you can't close some alerts )
- Object deletion is asynchronous resulting in the API returning a "GET" with containing an object thats already been deleted. This causes issues when attempting to get details on a deleted object


Solution: 

Automatically retry some tests if they fail. 