### PR TITLE
Support Image Summary API for Box

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -56,7 +56,7 @@ jobs:
           LW_API_SECRET: ${{ secrets.LW_API_SECRET }}
           LW_BASE_DOMAIN: ${{ secrets.LW_BASE_DOMAIN }}
       - name: Report Status
-        if: contains(github.ref, "main")
+        if: github.ref_name == 'main'
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}

--- a/laceworksdk/api/v2/vulnerabilities.py
+++ b/laceworksdk/api/v2/vulnerabilities.py
@@ -42,6 +42,7 @@ class VulnerabilitiesAPI:
         self.containers = self.ContainerVulnerabilitiesAPI(session, self._base_path)
         self.hosts = self.HostVulnerabilitiesAPI(session, self._base_path)
         self.packages = self.SoftwarePackagesAPI(session, self._base_path)
+        self.imageSummary = self.ImageSummaryVulnerabilitiesAPI(session, self._base_path)
 
     class ContainerVulnerabilitiesAPI(SearchEndpoint):
         """A class used to represent the Container Vulnerabilities API endpoint."""
@@ -90,6 +91,12 @@ class VulnerabilitiesAPI:
             )
 
             return response.json()
+    
+    class ImageSummaryVulnerabilitiesAPI(SearchEndpoint):
+        """A class used to represent the ImageSummary Vulnerabilities API endpoint."""
+
+        RESOURCE = "ImageSummary"
+
 
     class HostVulnerabilitiesAPI(SearchEndpoint):
         """A class used to represent the Host Vulnerabilities API endpoint."""

--- a/tests/api/v2/test_vulnerabilities.py
+++ b/tests/api/v2/test_vulnerabilities.py
@@ -23,7 +23,8 @@ class TestVulnerabilitesEndpoint(SearchEndpoint):
     OBJECT_TYPE = VulnerabilitiesAPI
     OBJECT_MAP = {
         "containers": VulnerabilitiesAPI.ContainerVulnerabilitiesAPI,
-        "hosts": VulnerabilitiesAPI.HostVulnerabilitiesAPI
+        "hosts": VulnerabilitiesAPI.HostVulnerabilitiesAPI,
+        "imageSummary": VulnerabilitiesAPI.ImageSummaryVulnerabilitiesAPI
     }
 
     def test_vulnerabilities_containers_api_scan(self, api_object, request):
@@ -67,3 +68,16 @@ class TestVulnerabilitesEndpoint(SearchEndpoint):
             "pkgVer": "1.1.1-1ubuntu2.1~20.04"
         }])
         assert "data" in response.keys()
+    
+    def test_vulnerabilities_image_summary_search(api, api_object):
+        json = {
+            "timeFilter": {
+                "startTime": "2024-03-18T00:00:00Z",
+                "endTime":   "2024-03-19T08:00:00Z"
+            },
+            "filters" : [
+                {"field": "ndvContainers", "expression": "gt", "value": 0}
+            ]
+        } 
+        response = api_object.imageSummary.search(json)
+        assert "data" in next(response, None)


### PR DESCRIPTION
Summarazies image details on all the evaluations in a given time range.
POST https://YourLacework.lacework.net/api/v2/Vulnerabilities/ImageSummary/search
Lacework highly recommends specifying a time range. Without a specified time range, the request uses the default time range of 24 hours prior to the current time. The maximum time range per API request is 7 days. To use the current time as the end time, exclude the endTime field.
You can optionally filter Images for active containers only by adding ndvContainers  field
{ "timeFilter": { "startTime": "2021-08-28T20:30:00Z", "endTime": "2021-08-28T22:30:00Z"}, "filters": [ { "field": "ndvContainers", "expression": "gt", "value": 0} ] }
