### PR TITLE
ci: send alerts to Slack only from `main` branch (#170)

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -56,7 +56,7 @@ jobs:
           LW_API_SECRET: ${{ secrets.LW_API_SECRET }}
           LW_BASE_DOMAIN: ${{ secrets.LW_BASE_DOMAIN }}
       - name: Report Status
-        if: always()
+        if: contains(github.ref, "main")
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
<img src="https://media4.giphy.com/media/3oriOfixsKjISS9kR2/giphy.gif"/>